### PR TITLE
Replace token counting with line count for CLAUDE.md validation

### DIFF
--- a/.claude/skills/github-operations/SKILL.md
+++ b/.claude/skills/github-operations/SKILL.md
@@ -14,6 +14,20 @@ Expert in GitHub workflows and operations using the GitHub MCP server for Drift 
 - Maintain clean Git history
 - Follow contribution workflows
 
+## IMPORTANT: Always Determine Repository Information First
+
+**Before using any GitHub MCP tools**, you MUST determine the actual repository owner and name from git:
+
+```bash
+git remote get-url origin
+```
+
+Parse the output to extract the owner and repository name. For example:
+- `https://github.com/jarosser06/drift.git` → owner: `jarosser06`, repo: `drift`
+- `git@github.com:jarosser06/drift.git` → owner: `jarosser06`, repo: `drift`
+
+Never assume or hardcode repository information. Always check git first.
+
 ## Branch Naming Convention
 
 Format: `issue-<number>-<short-description>`

--- a/.drift.yaml
+++ b/.drift.yaml
@@ -478,7 +478,7 @@ rule_definitions:
   claude_md_quality:
     description: "CLAUDE.md file violates quality best practices"
     scope: project_level
-    context: "CLAUDE.md should be concise (<1500 tokens for Anthropic), use pointers instead of large code blocks (>20 lines), avoid linting rules (use automated tools), and provide essential project context."
+    context: "CLAUDE.md should be concise (<300 lines), use pointers instead of large code blocks (>20 lines), avoid linting rules (use automated tools), and provide essential project context."
     requires_project_context: false
     supported_clients:
       - claude-code
@@ -489,14 +489,12 @@ rule_definitions:
       bundle_strategy: individual
       resource_patterns: []
     phases:
-      - name: check_token_count
-        type: token_count
+      - name: check_line_count
+        type: file_size
         file_path: CLAUDE.md
-        max_count: 1500
-        params:
-          provider: anthropic
-        failure_message: "CLAUDE.md exceeds 1500 tokens (Anthropic best practice for context efficiency)"
-        expected_behavior: "CLAUDE.md should be concise and under 1500 tokens"
+        max_count: 300
+        failure_message: "CLAUDE.md exceeds 300 lines (best practice for concise context)"
+        expected_behavior: "CLAUDE.md should be concise and under 300 lines"
       - name: content_quality
         type: prompt
         prompt: |
@@ -504,7 +502,7 @@ rule_definitions:
 
           CRITICAL ISSUES (report these):
 
-          **Token Efficiency**:
+          **Conciseness**:
           1. Contains code blocks longer than 20 lines (count lines between ``` fences for each block)
           2. Large narrative paragraphs (>8 consecutive non-bullet lines) instead of bullet points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ uv pip install -e ".[dev]"
 - Minimum 90% coverage (enforced by pytest)
 - Comprehensive test coverage for all new features
 - Use pytest fixtures for common test setup
-- Mock external API calls (Anthropic, AWS Bedrock)
+- Mock external API calls (Anthropic, AWS Bedrock, Claude Code CLI)
 
 ### Code Quality
 - All code must pass linters before commit
@@ -92,8 +92,9 @@ uv pip install -e ".[dev]"
 ## Provider Support
 
 Drift supports multiple LLM providers:
-- **Anthropic API** (recommended): Set `ANTHROPIC_API_KEY`
+- **Anthropic API**: Set `ANTHROPIC_API_KEY`
 - **AWS Bedrock**: Configure with `aws configure`
+- **Claude Code**: Use existing Claude Code CLI (no API key needed)
 
 Configuration in `.drift.yaml` (see README.md for details).
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,6 +76,30 @@ AWS Bedrock Provider
 
     default_model: sonnet
 
+Claude Code Provider
+~~~~~~~~~~~~~~~~~~~~
+
+Claude Code provider uses your existing Claude Code installation. Requires the ``claude`` CLI to be installed and in your PATH. No API key needed - uses your Claude Code session.
+
+.. code-block:: yaml
+
+    # .drift.yaml
+    providers:
+      claude-code:
+        provider: claude-code
+        params: {}
+
+    models:
+      sonnet:
+        provider: claude-code
+        model_id: sonnet  # or 'opus', 'haiku'
+        params:
+          max_tokens: 4096
+          temperature: 0.0
+          timeout: 120  # Optional: timeout in seconds (default: 120)
+
+    default_model: sonnet
+
 Multi-Provider Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,6 +63,19 @@ Configure your AWS credentials:
 
 Bedrock requires appropriate IAM permissions for model access.
 
+Claude Code
+~~~~~~~~~~~
+
+Claude Code provider uses your existing Claude Code CLI installation. No API key needed.
+
+Ensure the ``claude`` CLI is installed and in your PATH:
+
+.. code-block:: bash
+
+    claude --version
+
+If not installed, visit the Claude Code documentation for installation instructions.
+
 Verifying Installation
 ----------------------
 

--- a/src/drift/providers/claude_code.py
+++ b/src/drift/providers/claude_code.py
@@ -136,7 +136,7 @@ class ClaudeCodeProvider(Provider):
 
         # Build command
         # Use -p for headless prompt mode and --output-format json for structured output
-        # Use --no-mcp to disable MCP servers for clean provider execution
+        # Use --mcp-config with empty config and --strict-mcp-config to disable MCP servers
         cmd = [
             "claude",
             "-p",
@@ -145,7 +145,9 @@ class ClaudeCodeProvider(Provider):
             model_name,
             "--output-format",
             "json",
-            "--no-mcp",
+            "--mcp-config",
+            '{"mcpServers":{}}',
+            "--strict-mcp-config",
         ]
 
         # Add system prompt if provided (if claude CLI supports it)

--- a/src/drift/validation/validators/core/file_validators.py
+++ b/src/drift/validation/validators/core/file_validators.py
@@ -206,8 +206,13 @@ class FileSizeValidator(BaseValidator):
 class TokenCountValidator(BaseValidator):
     """Validator for checking file token count.
 
+    DEPRECATED: This validator requires provider-specific authentication and dependencies.
+    For example, Anthropic token counting requires API credentials, making it unsuitable
+    for offline programmatic checks. Use FileSizeValidator with line count (max_count/min_count)
+    instead for a general, offline validation approach.
+
     Supports multiple tokenizer providers:
-    - anthropic: For Claude models (requires 'anthropic' package)
+    - anthropic: For Claude models (requires 'anthropic' package + API credentials)
     - openai: For OpenAI models (requires 'tiktoken' package)
     - llama: For Llama models (requires 'transformers' package)
     """


### PR DESCRIPTION
## Summary

- Replaced token counting with line counting for CLAUDE.md validation to eliminate authentication dependencies
- Updated validation rule to check for 300 lines instead of 1500 tokens (Anthropic best practice)
- Fixed Claude Code provider MCP configuration to use `--mcp-config` with empty config instead of deprecated `--no-mcp` flag
- Added Claude Code as a provider option in documentation and project instructions
- Deprecated TokenCountValidator in favor of FileSizeValidator for offline validation

## Motivation

Token counting requires provider-specific authentication (e.g., Anthropic API key), making it unsuitable for offline programmatic checks. Line counting provides a simple, general, and offline-friendly alternative that achieves the same goal of keeping CLAUDE.md concise.

## Test Plan

- [x] All unit tests passing (914 tests)
- [x] Coverage at 94% (exceeds 90% requirement)
- [x] All linters passing (flake8, black, isort, mypy)
- [x] Manual testing of ClaudeCodeProvider with mocked subprocess calls
- [x] Validated FileSizeValidator line counting logic
- [x] Verified TokenCountValidator marked as deprecated with clear docstring

## Changes

### Modified

- **`.drift.yaml`** - Updated `claude_md_quality` rule to use `file_size` validator with 300 line limit instead of `token_count` with 1500 token limit
- **`src/drift/validation/validators/core/file_validators.py:206-217`** - Added deprecation notice to TokenCountValidator docstring explaining why FileSizeValidator is preferred
- **`src/drift/providers/claude_code.py:139-150`** - Fixed MCP config to use `--mcp-config '{"mcpServers":{}}'` with `--strict-mcp-config` instead of deprecated `--no-mcp` flag
- **`CLAUDE.md`** - Added Claude Code to provider list and updated test mocking documentation
- **`docs/configuration.rst:79-101`** - Added Claude Code provider configuration section with example
- **`docs/installation.rst:66-77`** - Added Claude Code installation instructions
- **`.claude/skills/github-operations/SKILL.md:17-29`** - Added instructions to always determine repository information from git before using GitHub MCP tools

### Test Coverage

Comprehensive test suite for ClaudeCodeProvider:
- 625 lines of tests in `tests/unit/test_claude_code_provider.py`
- Tests initialization, generation, caching, error handling, model extraction, and edge cases
- All existing tests for FileSizeValidator and TokenCountValidator remain passing

## Related Issues

Fixes the dependency on Anthropic API credentials for programmatic validation checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>