### PR TITLE
Improve /work-on-issue command to require manual commit approval

### DIFF
--- a/.claude/commands/work-on-issue.md
+++ b/.claude/commands/work-on-issue.md
@@ -37,9 +37,12 @@ Implement a complete workflow for a GitHub issue from start to finish.
    - Run `./test.sh --coverage` to verify coverage meets 90%+ requirement
    - Validate all requirements are met
 
-7. **Commit**
-   - Create descriptive commit message
-   - Reference issue number in commit
+7. **Present Summary**
+   - Provide detailed summary of changes made
+   - List all files created and modified
+   - Show quality metrics (coverage, test counts)
+   - Give user opportunity to review before committing
+   - DO NOT automatically commit - wait for user to review and commit manually
 
 **Usage:**
 ```
@@ -60,6 +63,7 @@ The assistant will:
 4. **MUST use Task tool with subagent_type='developer'** for implementation - do NOT implement code directly
 5. **MUST use Task tool with subagent_type='qa'** for testing - do NOT write tests directly
 6. Validate quality with ./lint.sh and ./test.sh
-7. Create descriptive commit referencing the issue
+7. Present summary of changes for user review
+8. **DO NOT commit automatically** - user will review and commit when ready
 
-This workflow ensures specialized agents handle their domains of expertise from issue assignment to implementation ready for PR.
+This workflow ensures specialized agents handle their domains of expertise from issue assignment to implementation, while giving the user full control over when to commit changes.


### PR DESCRIPTION
## Summary

- Updated `/work-on-issue` command to not auto-commit changes
- Workflow now presents summary and waits for user approval before committing
- Gives users full control over reviewing changes before they're committed
- Improves transparency and reduces surprise commits

## Context

Previously, the `/work-on-issue` command would automatically create commits after implementing changes. This could be surprising to users who wanted to review the changes first or make additional modifications before committing.

## Changes

### Modified
- `.claude/commands/work-on-issue.md:40-44` - Changed step 7 from "Commit" to "Present Summary"
- `.claude/commands/work-on-issue.md:66-68` - Updated assistant instructions to present summary instead of auto-committing
- `.claude/commands/work-on-issue.md:70` - Updated workflow description to emphasize user control

## Related Issues

N/A - Proactive improvement to command workflow

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>