### PR TITLE
Issue #35: Add support for custom validator plugins

### DIFF
--- a/.claude/commands/work-on-issue.md
+++ b/.claude/commands/work-on-issue.md
@@ -27,20 +27,34 @@ Implement a complete workflow for a GitHub issue from start to finish.
    - The developer agent will follow Python documentation standards and write clean code
    - DO NOT implement the code yourself - delegate to the developer agent
 
-5. **Testing**
+5. **Documentation Updates** (if applicable)
+   - **MANDATORY:** Update `docs/` directory if changes involve:
+     - New features or functionality
+     - Changes to existing features or behavior
+     - New validators, rules, or configuration options
+     - Changes to CLI commands or usage
+   - Common documentation files to update:
+     - `docs/validators.md` - For validator changes
+     - `docs/README.md` - For documentation build/structure changes
+     - Project README.md - For user-facing feature changes
+   - Use the Task tool with subagent_type='documentation' for doc updates
+   - DO NOT skip this step if changes are user-facing or add/modify functionality
+
+6. **Testing**
    - **MANDATORY:** Use the Task tool with subagent_type='qa' to create comprehensive tests
    - The qa agent will ensure 90%+ code coverage
    - DO NOT write tests yourself - delegate to the qa agent
 
-6. **Validation**
+7. **Validation**
    - Run `./lint.sh` to ensure code quality
    - Run `./test.sh --coverage` to verify coverage meets 90%+ requirement
    - Validate all requirements are met
 
-7. **Present Summary**
+8. **Present Summary**
    - Provide detailed summary of changes made
    - List all files created and modified
    - Show quality metrics (coverage, test counts)
+   - Highlight documentation updates (if any)
    - Give user opportunity to review before committing
    - DO NOT automatically commit - wait for user to review and commit manually
 
@@ -61,9 +75,10 @@ The assistant will:
 2. Fetch and understand the issue requirements using `mcp__github__get_issue`
 3. Create a feature branch with proper naming
 4. **MUST use Task tool with subagent_type='developer'** for implementation - do NOT implement code directly
-5. **MUST use Task tool with subagent_type='qa'** for testing - do NOT write tests directly
-6. Validate quality with ./lint.sh and ./test.sh
-7. Present summary of changes for user review
-8. **DO NOT commit automatically** - user will review and commit when ready
+5. **MUST update docs/ if changes are user-facing** - use Task tool with subagent_type='documentation' for doc updates
+6. **MUST use Task tool with subagent_type='qa'** for testing - do NOT write tests directly
+7. Validate quality with ./lint.sh and ./test.sh
+8. Present summary of changes for user review (including documentation updates)
+9. **DO NOT commit automatically** - user will review and commit when ready
 
-This workflow ensures specialized agents handle their domains of expertise from issue assignment to implementation, while giving the user full control over when to commit changes.
+This workflow ensures specialized agents handle their domains of expertise from issue assignment to implementation, and that all user-facing changes are properly documented before giving the user full control over when to commit changes.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,7 @@
       "Skill(python-docs)",
       "Skill(python-basics)",
       "Skill(code-review)",
+      "Skill(commit-messages)",
       "Skill(github-operations)",
       "Skill(pr-writing)",
       "Skill(issue-writing)",

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -78,14 +78,22 @@ Expert in conducting thorough, constructive code reviews using the GitHub MCP se
 - Clear parameter descriptions
 - Return value documented
 - Examples for complex features
-- README updates if needed
 - Inline comments where helpful
+- **CRITICAL: Documentation updated for any code changes**
+  - New attributes/parameters documented in docstrings
+  - Configuration changes documented where appropriate
+  - Breaking changes clearly documented
+  - CLI changes reflected in help text
 
 **Questions to Ask:**
 - Can someone understand this without asking?
 - Are all parameters documented?
 - Do examples cover common use cases?
 - Is the "why" explained for non-obvious code?
+- **Do documentation updates match code changes?**
+- Are all new public APIs documented?
+- Are configuration changes documented?
+- Are breaking changes clearly called out?
 
 ### 5. Security
 
@@ -199,6 +207,72 @@ mcp__github__create_pull_request_review(
 )
 ```
 
+## Recommendations Must Be Research-Backed
+
+**CRITICAL REQUIREMENT:** Any recommendations you make MUST be researched using authoritative sources.
+
+### Research Requirements
+
+**Before making ANY recommendation:**
+1. Use the `mcp__context7` tools to look up best practices from official documentation
+2. Verify recommendations against Python official docs, library official docs, or established standards
+3. Include source citations in your feedback
+
+**Example Research Process:**
+```python
+# To recommend a library or pattern, first research it:
+library_id = mcp__context7__resolve_library_id(libraryName="pytest")
+docs = mcp__context7__get_library_docs(
+    context7CompatibleLibraryID=library_id["libraries"][0]["id"],
+    topic="fixtures",
+    mode="code"
+)
+```
+
+### Valid Sources for Recommendations
+
+**✅ Acceptable:**
+- Python official documentation (python.org)
+- Library official documentation (via Context7 MCP)
+- PEP documents (Python Enhancement Proposals)
+- Project's own documentation and patterns
+
+**❌ Not Acceptable:**
+- Personal opinions without research
+- Assumptions about best practices
+- Recommendations based on other projects without verification
+- "Common knowledge" that isn't documented
+
+### Recommendation Guidelines
+
+**DO:**
+- Research each recommendation thoroughly
+- Cite specific documentation sections
+- Verify the recommendation applies to the project's Python version
+- Check if the pattern already exists in the codebase
+- Limit recommendations to well-researched, high-impact suggestions
+
+**DON'T:**
+- Make recommendations without research
+- Suggest libraries without checking their documentation
+- Recommend patterns you're unsure about
+- Provide excessive recommendations (quality over quantity)
+- Suggest "best practices" without authoritative sources
+
+**Example - Good Recommendation:**
+```
+Consider using `pytest.fixture(scope="session")` for the database connection.
+According to pytest documentation [via Context7], session-scoped fixtures are
+initialized once per test session, which will improve test performance.
+
+Source: pytest official docs - Fixture scopes
+```
+
+**Example - Bad Recommendation:**
+```
+You should probably use a session fixture here, it's faster.
+```
+
 ## Feedback Guidelines
 
 ### Be Constructive
@@ -245,7 +319,7 @@ This function is too long.
 - Security vulnerabilities
 - Bugs that will cause failures
 - Missing required tests
-- Breaking changes without migration
+- Breaking changes
 
 **Important (Should Fix):**
 - Code quality issues
@@ -266,7 +340,12 @@ This function is too long.
 - [ ] Code quality is good
 - [ ] Architecture is sound
 - [ ] Tests are comprehensive (90%+ coverage)
-- [ ] Documentation is complete
+- [ ] **Documentation is complete and matches code changes**
+  - [ ] Docstrings added/updated for changed functions
+  - [ ] Configuration changes documented where appropriate
+  - [ ] CLI help text updated if needed
+  - [ ] Breaking changes clearly documented
+- [ ] **Any recommendations are research-backed with citations**
 - [ ] No security issues
 - [ ] Performance is acceptable
 - [ ] Linters pass

--- a/.claude/skills/code-review/resources/checklist.md
+++ b/.claude/skills/code-review/resources/checklist.md
@@ -58,13 +58,28 @@ Comprehensive checklist for reviewing code in Drift.
 
 ## Documentation
 
+**CRITICAL: Verify documentation matches code changes**
+
 - [ ] Docstrings on all public functions
 - [ ] Parameters documented with `-- param:`
 - [ ] Return values documented
 - [ ] Exceptions documented (Raises)
-- [ ] README updated if needed
-- [ ] CLI help text updated
-- [ ] Examples for complex features
+- [ ] **Configuration changes documented where appropriate**
+- [ ] **CLI changes reflected in help text**
+- [ ] Examples for complex features in docstrings
+- [ ] **All code changes reflected in documentation**
+- [ ] **New attributes/parameters documented in docstrings**
+- [ ] **Breaking changes clearly documented**
+
+## Recommendations
+
+**CRITICAL: All recommendations must be research-backed**
+
+- [ ] Recommendations researched using Context7 MCP or official docs
+- [ ] Sources cited for each recommendation
+- [ ] Recommendations verified against project's Python version
+- [ ] Recommendations checked against existing codebase patterns
+- [ ] Only high-impact, well-researched recommendations included
 
 ## Security
 

--- a/.claude/skills/code-review/resources/common-issues.md
+++ b/.claude/skills/code-review/resources/common-issues.md
@@ -182,7 +182,35 @@ def test_parse_conversation_missing_messages_key():
 
 ## Documentation Issues
 
-### 9. Missing or Poor Docstrings
+### 9. Code Changes Without Documentation Updates
+
+**❌ WRONG:**
+```python
+# New feature added to analyzer.py
+class DriftAnalyzer:
+    def __init__(self, config: dict, plugins: list):  # plugins is NEW
+        self.config = config
+        self.plugins = plugins  # New parameter!
+        # But docstring not updated! Missing plugins parameter!
+```
+
+**✅ RIGHT:**
+```python
+# analyzer.py - Code and docstring updated
+class DriftAnalyzer:
+    def __init__(self, config: dict, plugins: list):
+        """Initialize drift analyzer.
+
+        -- config: Configuration dictionary
+        -- plugins: List of validation plugins to load  # NEW parameter documented
+        """
+        self.config = config
+        self.plugins = plugins
+```
+
+**Why it matters:** Outdated documentation confuses users and wastes time.
+
+### 10. Missing or Poor Docstrings
 
 **❌ WRONG:**
 ```python

--- a/.claude/skills/code-review/resources/feedback-examples.md
+++ b/.claude/skills/code-review/resources/feedback-examples.md
@@ -255,6 +255,50 @@ Looking forward to the updates!
 LGTM! Simple, focused fix with tests. Ready to merge. ✅
 ```
 
+## Research-Backed Recommendations
+
+**CRITICAL:** All recommendations MUST be researched using authoritative sources.
+
+### Good - Research-Backed Recommendation
+
+```
+Consider using `pytest.fixture(scope="session")` for the database connection
+in tests/conftest.py:12.
+
+According to the pytest documentation (researched via Context7 MCP), session-scoped
+fixtures are initialized once per test session and shared across all tests, which
+will significantly improve test performance for the test suite.
+
+Source: pytest official docs - "Fixture scopes" section
+Reference: https://docs.pytest.org/en/stable/fixture.html#scope
+```
+
+### Bad - Unresearched Recommendation
+
+```
+You should use a session fixture, it's better for performance.
+```
+
+### Good - Library Recommendation
+
+```
+For structured logging, consider using Python's built-in `logging.dictConfig`
+instead of a third-party library.
+
+Research via Python official docs shows that dictConfig (available in stdlib
+since Python 3.2) supports JSON/YAML configuration and structured output without
+adding dependencies.
+
+Source: Python 3.10+ logging.config documentation
+Applied to project: Python 3.10+ requirement confirmed in pyproject.toml
+```
+
+### Bad - Assumption-Based Recommendation
+
+```
+Consider using structlog for better logging.
+```
+
 ## Tips for Good Feedback
 
 1. **Be specific** - Reference file names and line numbers
@@ -265,3 +309,5 @@ LGTM! Simple, focused fix with tests. Ready to merge. ✅
 6. **Acknowledge good work** - Point out what's done well
 7. **Ask questions** - "Is there a reason you chose X over Y?"
 8. **Focus on code, not person** - "This function" not "You"
+9. **Research recommendations** - Use Context7 MCP or official docs before suggesting patterns
+10. **Cite sources** - Always include documentation references for recommendations

--- a/.claude/skills/commit-messages/SKILL.md
+++ b/.claude/skills/commit-messages/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: commit-messages
+description: Expert in writing concise, factual commit messages without AI fluff
+version: 1.0.0
+dependencies: []
+---
+
+# Commit Messages Skill
+
+You are an expert at writing **concise, factual commit messages** that describe **what changed**, not benefits, testing plans, or AI-generated fluff.
+
+## Core Principles
+
+1. **State what changed** - Be direct and specific
+2. **Include why ONLY if explicitly known** - From issue, user request, or code context
+3. **No AI assumptions** - Don't make up reasons or benefits
+4. **No boilerplate** - No "testing", "benefits", or generic statements
+5. **Keep it tight** - Short, factual, to the point
+
+## Format
+
+```
+<action> <what changed>
+
+[Optional: Why, if explicitly known from issue/user/context]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+## Good Examples
+
+```
+Add default failure messages to all validators
+
+Validators now provide default_failure_message and default_expected_behavior
+properties. Makes failure_message and expected_behavior optional in ValidationRule.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+```
+Fix mypy type errors from optional failure_message
+
+Changed validators to use _get_failure_message() helper instead of accessing
+rule.failure_message directly to handle Optional[str] correctly.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+```
+Add support for custom validator plugins
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+## Bad Examples (DON'T DO THIS)
+
+❌ **Too much fluff:**
+```
+Add default failure messages to validators
+
+This commit adds default failure message support to all validators,
+improving the developer experience by making custom messages optional.
+This will help users get started faster and reduce boilerplate.
+
+Benefits:
+- Less configuration required
+- Better developer experience
+- Consistent error messages
+
+Testing:
+- Added 42 new tests
+- All tests passing
+- Coverage increased
+```
+
+❌ **Made-up context:**
+```
+Fix mypy type errors
+
+This fixes type errors to improve code quality and maintainability.
+The changes ensure better type safety across the codebase.
+```
+
+❌ **Generic statements:**
+```
+Update validators
+
+Made improvements to the validator system for better functionality.
+```
+
+## Action Words
+
+Use these verbs to describe what you did:
+
+- **Add** - New feature, file, function, test
+- **Fix** - Bug fix, error correction
+- **Update** - Modify existing code
+- **Remove** - Delete code, files, features
+- **Refactor** - Restructure without changing behavior
+- **Rename** - Change names of files, functions, variables
+- **Move** - Relocate code
+- **Extract** - Pull code into separate function/file
+- **Merge** - Combine branches, resolve conflicts
+
+## Context Guidelines
+
+Include context (the "why") ONLY when:
+
+1. **Explicitly stated in the issue** - "Fix circular dependency detection per #123"
+2. **User directly told you** - "User requested JSON output for CI/CD"
+3. **Obvious from code** - "Fix off-by-one error in line counting"
+4. **Breaking change** - "Remove deprecated validate_v1() method"
+
+DON'T include context when:
+
+- You're guessing about benefits
+- You're assuming user intent
+- You're adding generic statements like "improves maintainability"
+- You're listing what you tested
+
+## Length Guidelines
+
+- **Title**: 50-72 characters max
+- **Body**: Optional, use ONLY when necessary
+- **Total**: Aim for 1-3 lines plus footer
+- **Maximum**: 5 lines of actual content (not counting footer)
+
+## Remember
+
+You are writing for **developers reading git log**, not for documentation or marketing. They want to know **what changed** so they can understand the commit quickly. Everything else is noise.

--- a/.drift_rules.yaml
+++ b/.drift_rules.yaml
@@ -410,7 +410,7 @@ claude_md_missing:
     - claude-code
   phases:
     - name: check_file
-      type: file_exists
+      type: core:file_exists
       file_path: CLAUDE.md
       failure_message: "CLAUDE.md file is missing from project root"
       expected_behavior: "Project should have CLAUDE.md file documenting structure and conventions"
@@ -430,7 +430,7 @@ command_duplicate_dependencies:
     bundle_strategy: individual
   phases:
     - name: check_duplicates
-      type: dependency_duplicate
+      type: core:dependency_duplicate
       description: "Check for redundant transitive dependencies in commands"
       failure_message: "Found redundant dependency: {duplicate_resource}"
       expected_behavior: "Commands should only declare direct dependencies, not transitive ones"
@@ -453,7 +453,7 @@ skill_duplicate_dependencies:
     bundle_strategy: individual
   phases:
     - name: check_duplicates
-      type: dependency_duplicate
+      type: core:dependency_duplicate
       description: "Check for redundant transitive dependencies in skills"
       failure_message: "Found redundant dependency: {duplicate_resource}"
       expected_behavior: "Skills should only declare direct dependencies, not transitive ones"
@@ -470,7 +470,7 @@ skill_filename_consistency:
     - claude-code
   phases:
     - name: check_skill_files
-      type: file_exists
+      type: core:file_exists
       file_path: .claude/skills/*/SKILL.md
       failure_message: "Found skill directory with skill.md (lowercase) instead of SKILL.md (uppercase)"
       expected_behavior: "All skill directories should contain SKILL.md (uppercase) as the main skill file"
@@ -527,7 +527,7 @@ agent_duplicate_dependencies:
     bundle_strategy: individual
   phases:
     - name: check_duplicates
-      type: dependency_duplicate
+      type: core:dependency_duplicate
       description: "Check for redundant transitive dependencies in agents"
       failure_message: "Found redundant dependency: {duplicate_resource}"
       expected_behavior: "Agents should only declare direct dependencies, not transitive ones"
@@ -550,7 +550,7 @@ command_broken_links:
     bundle_strategy: individual
   phases:
     - name: check_links
-      type: markdown_link
+      type: core:markdown_link
       description: "Check for broken links in command documentation"
       failure_message: "Found broken links in commands"
       expected_behavior: "All file references and links should be valid"
@@ -580,7 +580,7 @@ skill_broken_links:
     bundle_strategy: individual
   phases:
     - name: check_links
-      type: markdown_link
+      type: core:markdown_link
       description: "Check for broken links in skill documentation"
       failure_message: "Found broken links in skills"
       expected_behavior: "All file references and links should be valid"
@@ -610,7 +610,7 @@ agent_broken_links:
     bundle_strategy: individual
   phases:
     - name: check_links
-      type: markdown_link
+      type: core:markdown_link
       description: "Check for broken links in agent documentation"
       failure_message: "Found broken links in agents"
       expected_behavior: "All file references and links should be valid"
@@ -635,7 +635,7 @@ claude_skill_permissions:
     - claude-code
   phases:
     - name: check_skill_permissions
-      type: claude_skill_settings
+      type: core:claude_skill_settings
       failure_message: "Skills missing from .claude/settings.json permissions.allow array"
       expected_behavior: "Every skill directory in .claude/skills/ should have a corresponding Skill(name) entry in .claude/settings.json"
 
@@ -646,7 +646,7 @@ claude_settings_duplicates:
   requires_project_context: true
   phases:
     - name: check_duplicate_permissions
-      type: claude_settings_duplicates
+      type: core:claude_settings_duplicates
       failure_message: "Duplicate permission entries found in .claude/settings.json"
       expected_behavior: "All permission entries in .claude/settings.json permissions.allow should be unique"
 
@@ -657,7 +657,7 @@ claude_mcp_permissions:
   requires_project_context: true
   phases:
     - name: check_mcp_permissions
-      type: claude_mcp_permissions
+      type: core:claude_mcp_permissions
       failure_message: "MCP servers missing from .claude/settings.json permissions.allow array"
       expected_behavior: "Every MCP server in .mcp.json should have a corresponding MCP(server-name) entry in .claude/settings.json"
 
@@ -676,7 +676,7 @@ claude_md_quality:
     resource_patterns: []
   phases:
     - name: check_line_count
-      type: file_size
+      type: core:file_size
       file_path: CLAUDE.md
       max_count: 300
       failure_message: "CLAUDE.md exceeds 300 lines (best practice for concise context)"
@@ -825,7 +825,7 @@ agent_frontmatter:
     bundle_strategy: individual
   phases:
     - name: check_frontmatter
-      type: yaml_frontmatter
+      type: core:yaml_frontmatter
       params:
         required_fields:
           - name
@@ -877,7 +877,7 @@ command_frontmatter:
     bundle_strategy: individual
   phases:
     - name: check_frontmatter
-      type: yaml_frontmatter
+      type: core:yaml_frontmatter
       params:
         required_fields:
           - description
@@ -954,7 +954,7 @@ agent_tools_format:
     bundle_strategy: individual
   phases:
     - name: check_tools_comma_separated
-      type: regex_match
+      type: core:regex_match
       description: "Validate tools field uses comma-separated format on single line"
       params:
         pattern: '^tools:\s+[A-Za-z][\w_]+(?:,\s*[A-Za-z][\w_]+)*\s*$'
@@ -976,7 +976,7 @@ skill_circular_dependencies:
     bundle_strategy: individual
   phases:
     - name: check_cycles
-      type: circular_dependencies
+      type: core:circular_dependencies
       description: "Check for circular dependencies in skill dependency graphs"
       failure_message: "Circular dependency detected: {circular_path}"
       expected_behavior: "Skills should not have circular dependency cycles"
@@ -999,7 +999,7 @@ command_circular_dependencies:
     bundle_strategy: individual
   phases:
     - name: check_circular_deps
-      type: claude_circular_dependencies
+      type: core:claude_circular_dependencies
       description: "Detect circular dependency cycles"
       params:
         resource_dirs:
@@ -1023,7 +1023,7 @@ skill_max_depth:
     bundle_strategy: individual
   phases:
     - name: check_depth
-      type: claude_max_dependency_depth
+      type: core:claude_max_dependency_depth
       description: "Ensure dependencies don't exceed maximum depth"
       params:
         max_depth: 3
@@ -1048,7 +1048,7 @@ agent_duplicate_dependencies_claude:
     bundle_strategy: individual
   phases:
     - name: check_duplicates
-      type: claude_dependency_duplicate
+      type: core:claude_dependency_duplicate
       description: "Check for redundant transitive dependencies"
       params:
         resource_dirs:

--- a/src/drift/cli/commands/analyze.py
+++ b/src/drift/cli/commands/analyze.py
@@ -91,6 +91,10 @@ def _merge_results(
     for type_name, count in doc_result.summary.by_type.items():
         merged_summary.by_type[type_name] = merged_summary.by_type.get(type_name, 0) + count
 
+    # Merge by_group counts
+    for group_name, count in doc_result.summary.by_group.items():
+        merged_summary.by_group[group_name] = merged_summary.by_group.get(group_name, 0) + count
+
     # Merge rule statistics
     if conv_result.summary.rules_checked and doc_result.summary.rules_checked:
         merged_summary.rules_checked = list(

--- a/src/drift/cli/output/json.py
+++ b/src/drift/cli/output/json.py
@@ -42,6 +42,7 @@ class JsonFormatter(OutputFormatter):
                 "total_rule_violations": result.summary.total_rule_violations,
                 "conversations_with_drift": result.summary.conversations_with_drift,
                 "conversations_without_drift": result.summary.conversations_without_drift,
+                "by_group": result.summary.by_group,
                 "by_type": result.summary.by_type,
                 "by_agent": result.summary.by_agent,
             },

--- a/src/drift/cli/output/markdown.py
+++ b/src/drift/cli/output/markdown.py
@@ -143,6 +143,13 @@ class MarkdownFormatter(OutputFormatter):
                 count_str = self._colorize(str(errored_count), self.YELLOW)
                 lines.append(f"- Checks errored: {count_str}")
 
+        # By group
+        if result.summary.by_group:
+            group_counts = ", ".join(
+                f"{group} ({count})" for group, count in result.summary.by_group.items()
+            )
+            lines.append(f"- By group: {group_counts}")
+
         # By type
         if result.summary.by_type:
             type_counts = ", ".join(

--- a/src/drift/core/types.py
+++ b/src/drift/core/types.py
@@ -157,6 +157,9 @@ class AnalysisSummary(BaseModel):
     by_type: Dict[str, int] = Field(
         default_factory=dict, description="Rule violation count by type"
     )
+    by_group: Dict[str, int] = Field(
+        default_factory=dict, description="Rule violation count by group"
+    )
     by_agent: Dict[str, int] = Field(
         default_factory=dict, description="Rule violation count by agent tool"
     )

--- a/src/drift/validation/validators/client/claude_dependency.py
+++ b/src/drift/validation/validators/client/claude_dependency.py
@@ -22,6 +22,11 @@ class ClaudeCircularDependenciesValidator(BaseCircularValidator):
     Uses YAML frontmatter 'skills' field for dependency information.
     """
 
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:claude_circular_dependencies"
+
     def __init__(self, loader: Any = None) -> None:
         """Initialize with ClaudeDependencyGraph.
 
@@ -53,6 +58,11 @@ class ClaudeMaxDependencyDepthValidator(BaseDepthValidator):
     Detects when Claude Code resource dependency chains exceed maximum depth.
     Uses YAML frontmatter 'skills' field for dependency information.
     """
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:claude_max_dependency_depth"
 
     def __init__(self, loader: Any = None) -> None:
         """Initialize with ClaudeDependencyGraph.
@@ -86,6 +96,11 @@ class ClaudeDependencyDuplicateValidator(BaseDuplicateValidator):
     is already declared by a transitive dependency.
     Uses YAML frontmatter 'skills' field for dependency information.
     """
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:claude_dependency_duplicate"
 
     def __init__(self, loader: Any = None) -> None:
         """Initialize with ClaudeDependencyGraph.

--- a/src/drift/validation/validators/core/file_validators.py
+++ b/src/drift/validation/validators/core/file_validators.py
@@ -11,9 +11,24 @@ class FileExistsValidator(BaseValidator):
     """Validator for checking file existence."""
 
     @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:file_exists"
+
+    @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
         """Return computation type for this validator."""
         return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message template."""
+        return "File {file_path} does not exist"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior description."""
+        return "File should exist"
 
     def validate(
         self,
@@ -79,14 +94,18 @@ class FileExistsValidator(BaseValidator):
 
         Returns DocumentRule representing the failure.
         """
+        # Create failure details for template substitution
+        failure_details = {"file_path": file_paths[0] if file_paths else "unknown"}
+
         return DocumentRule(
             bundle_id=bundle.bundle_id,
             bundle_type=bundle.bundle_type,
             file_paths=file_paths,
-            observed_issue=rule.failure_message,
-            expected_quality=rule.expected_behavior,
+            observed_issue=self._get_failure_message(rule, failure_details),
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}",
+            failure_details=failure_details,
         )
 
 
@@ -94,9 +113,24 @@ class FileSizeValidator(BaseValidator):
     """Validator for checking file size constraints."""
 
     @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:file_size"
+
+    @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
         """Return computation type for this validator."""
         return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message template."""
+        return "File size constraint violated"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior description."""
+        return "File should meet size constraints"
 
     def validate(
         self,
@@ -197,7 +231,7 @@ class FileSizeValidator(BaseValidator):
             bundle_type=bundle.bundle_type,
             file_paths=file_paths,
             observed_issue=observed_issue,
-            expected_quality=rule.expected_behavior,
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}",
         )
@@ -218,9 +252,24 @@ class TokenCountValidator(BaseValidator):
     """
 
     @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:token_count"
+
+    @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
         """Return computation type for this validator."""
         return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message template."""
+        return "File token count constraint violated"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior description."""
+        return "File should meet token count constraints"
 
     def validate(
         self,
@@ -405,7 +454,7 @@ class TokenCountValidator(BaseValidator):
             bundle_type=bundle.bundle_type,
             file_paths=file_paths,
             observed_issue=observed_issue,
-            expected_quality=rule.expected_behavior,
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}",
         )

--- a/src/drift/validation/validators/core/format_validators.py
+++ b/src/drift/validation/validators/core/format_validators.py
@@ -16,9 +16,24 @@ class JsonSchemaValidator(BaseValidator):
     """
 
     @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:json_schema"
+
+    @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
         """Return computation type for this validator."""
         return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message template."""
+        return "JSON schema validation failed"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior description."""
+        return "File should conform to JSON schema"
 
     def validate(
         self,
@@ -167,7 +182,7 @@ class JsonSchemaValidator(BaseValidator):
             bundle_type=bundle.bundle_type,
             file_paths=file_paths,
             observed_issue=observed_issue,
-            expected_quality=rule.expected_behavior,
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}",
         )
@@ -179,6 +194,11 @@ class YamlSchemaValidator(BaseValidator):
     Validates YAML files against schema specifications (same format as JSON Schema).
     Supports inline schemas via params or external schema files.
     """
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:yaml_schema"
 
     @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
@@ -349,7 +369,7 @@ class YamlSchemaValidator(BaseValidator):
             bundle_type=bundle.bundle_type,
             file_paths=file_paths,
             observed_issue=observed_issue,
-            expected_quality=rule.expected_behavior,
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}",
         )
@@ -361,6 +381,11 @@ class YamlFrontmatterValidator(BaseValidator):
     Validates that Markdown files have valid YAML frontmatter
     with required fields.
     """
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:yaml_frontmatter"
 
     @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
@@ -436,7 +461,7 @@ class YamlFrontmatterValidator(BaseValidator):
                     bundle_type=bundle.bundle_type,
                     file_paths=[f[0] for f in failed_files],
                     observed_issue="; ".join(messages),
-                    expected_quality=rule.expected_behavior,
+                    expected_quality=self._get_expected_behavior(rule),
                     rule_type="",
                     context=f"Validation rule: {rule.description}",
                 )
@@ -584,7 +609,7 @@ class YamlFrontmatterValidator(BaseValidator):
             bundle_type=bundle.bundle_type,
             file_paths=file_paths,
             observed_issue=observed_issue,
-            expected_quality=rule.expected_behavior,
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}",
         )

--- a/src/drift/validation/validators/core/list_validators.py
+++ b/src/drift/validation/validators/core/list_validators.py
@@ -12,9 +12,24 @@ class ListMatchValidator(BaseValidator):
     """Validator for checking if list items match expected values."""
 
     @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:list_match"
+
+    @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
         """Return computation type for this validator."""
         return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message template."""
+        return "List match validation failed"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior description."""
+        return "Items should match expected list"
 
     def validate(
         self,
@@ -101,8 +116,8 @@ class ListMatchValidator(BaseValidator):
             bundle_id=bundle.bundle_id,
             bundle_type=bundle.bundle_type,
             file_paths=[f.relative_path for f in bundle.files],
-            observed_issue=rule.failure_message,
-            expected_quality=rule.expected_behavior,
+            observed_issue=self._get_failure_message(rule),
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}. {context}",
         )
@@ -110,6 +125,11 @@ class ListMatchValidator(BaseValidator):
 
 class ListRegexMatchValidator(BaseValidator):
     """Validator for checking if list items match regex patterns in files."""
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:list_regex_match"
 
     @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
@@ -210,8 +230,8 @@ class ListRegexMatchValidator(BaseValidator):
             bundle_id=bundle.bundle_id,
             bundle_type=bundle.bundle_type,
             file_paths=[f.relative_path for f in bundle.files],
-            observed_issue=rule.failure_message,
-            expected_quality=rule.expected_behavior,
+            observed_issue=self._get_failure_message(rule),
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}. {context}",
         )

--- a/src/drift/validation/validators/core/regex_validators.py
+++ b/src/drift/validation/validators/core/regex_validators.py
@@ -12,9 +12,24 @@ class RegexMatchValidator(BaseValidator):
     """Validator for checking if file content matches a regex pattern."""
 
     @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:regex_match"
+
+    @property
     def computation_type(self) -> Literal["programmatic", "llm"]:
         """Return computation type for this validator."""
         return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message template."""
+        return "Pattern match validation failed"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior description."""
+        return "File should match the specified pattern"
 
     def validate(
         self,
@@ -166,8 +181,8 @@ class RegexMatchValidator(BaseValidator):
             bundle_id=bundle.bundle_id,
             bundle_type=bundle.bundle_type,
             file_paths=file_paths,
-            observed_issue=rule.failure_message,
-            expected_quality=rule.expected_behavior,
+            observed_issue=self._get_failure_message(rule),
+            expected_quality=self._get_expected_behavior(rule),
             rule_type="",  # Will be set by analyzer
             context=f"Validation rule: {rule.description}. {context}",
         )

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -656,7 +656,7 @@ class TestAnalyzeCommand:
                 phases=[
                     PhaseDefinition(
                         name="test",
-                        type="file_exists",
+                        type="core:file_exists",
                         file_path="test.txt",
                         failure_message="Missing",
                         expected_behavior="Should exist",
@@ -727,7 +727,7 @@ class TestAnalyzeCommand:
                 phases=[
                     PhaseDefinition(
                         name="test",
-                        type="file_exists",
+                        type="core:file_exists",
                         file_path="test.txt",
                         failure_message="Missing",
                         expected_behavior="Should exist",
@@ -812,7 +812,7 @@ class TestAnalyzeCommand:
                 phases=[
                     PhaseDefinition(
                         name="test",
-                        type="file_exists",
+                        type="core:file_exists",
                         file_path="test.txt",
                         failure_message="Missing",
                         expected_behavior="Should exist",
@@ -964,7 +964,7 @@ class TestAnalyzeCommand:
                 phases=[
                     PhaseDefinition(
                         name="test",
-                        type="file_exists",
+                        type="core:file_exists",
                         file_path="test.txt",
                         failure_message="Missing",
                         expected_behavior="Should exist",
@@ -998,7 +998,7 @@ class TestAnalyzeCommand:
                 phases=[
                     PhaseDefinition(
                         name="test",
-                        type="file_exists",
+                        type="core:file_exists",
                         file_path="test.txt",
                         failure_message="Missing",
                         expected_behavior="Should exist",
@@ -1162,7 +1162,7 @@ class TestAnalyzeCommand:
                 "phases": [
                     {
                         "name": "test",
-                        "type": "file_exists",
+                        "type": "core:file_exists",
                         "file_path": "test.txt",
                         "failure_message": "Missing",
                         "expected_behavior": "Should exist",
@@ -1222,7 +1222,7 @@ class TestAnalyzeCommand:
                     "phases": [
                         {
                             "name": "check",
-                            "type": "file_exists",
+                            "type": "core:file_exists",
                             "file_path": "README.md",
                             "failure_message": "Missing README",
                             "expected_behavior": "Should have README",
@@ -1280,7 +1280,7 @@ class TestAnalyzeCommand:
                     "phases": [
                         {
                             "name": "check",
-                            "type": "file_exists",
+                            "type": "core:file_exists",
                             "file_path": "README.md",
                             "failure_message": "Missing README",
                             "expected_behavior": "Should have README",
@@ -1347,7 +1347,7 @@ class TestAnalyzeCommand:
                     "phases": [
                         {
                             "name": "check",
-                            "type": "file_exists",
+                            "type": "core:file_exists",
                             "file_path": "README.md",
                             "failure_message": "Missing README",
                             "expected_behavior": "Should have README",
@@ -1405,7 +1405,7 @@ class TestAnalyzeCommand:
                     "phases": [
                         {
                             "name": "check",
-                            "type": "file_exists",
+                            "type": "core:file_exists",
                             "file_path": "README.md",
                             "failure_message": "Missing README",
                             "expected_behavior": "Should have README",
@@ -1456,7 +1456,7 @@ class TestAnalyzeCommand:
                     "phases": [
                         {
                             "name": "check_readme",
-                            "type": "file_exists",
+                            "type": "core:file_exists",
                             "file_path": "README.md",
                             "failure_message": "README.md is missing",
                             "expected_behavior": "Project should have README.md",
@@ -1471,7 +1471,7 @@ class TestAnalyzeCommand:
                     "phases": [
                         {
                             "name": "check_license",
-                            "type": "file_exists",
+                            "type": "core:file_exists",
                             "file_path": "LICENSE",
                             "failure_message": "LICENSE is missing",
                             "expected_behavior": "Project should have LICENSE",

--- a/tests/integration/test_e2e_comprehensive.py
+++ b/tests/integration/test_e2e_comprehensive.py
@@ -363,7 +363,7 @@ class TestComprehensiveE2E:
                         },
                         "rules": [
                             {
-                                "rule_type": "file_exists",
+                                "rule_type": "core:file_exists",
                                 "description": "CLAUDE.md must exist in project root",
                                 "file_path": "CLAUDE.md",
                                 "failure_message": "CLAUDE.md file is missing from project root",
@@ -1593,7 +1593,7 @@ rule_definitions:
         file_patterns: ["CLAUDE.md"]
         bundle_strategy: "collection"
       rules:
-        - rule_type: "file_exists"
+        - rule_type: "core:file_exists"
           description: "CLAUDE.md must exist"
           file_path: "CLAUDE.md"
           failure_message: "CLAUDE.md is missing"
@@ -1692,7 +1692,7 @@ rule_definitions:
         file_patterns: ["README.md"]
         bundle_strategy: "collection"
       rules:
-        - rule_type: "regex_match"
+        - rule_type: "core:regex_match"
           description: "README should contain version in X.Y.Z format"
           file_path: "README.md"
           pattern: "Version: \\\\d+\\\\.\\\\d+\\\\.\\\\d+"
@@ -1976,7 +1976,7 @@ rule_definitions:
         file_patterns: ["CLAUDE.md"]
         bundle_strategy: "collection"
       rules:
-        - rule_type: "file_exists"
+        - rule_type: "core:file_exists"
           description: "CLAUDE.md must exist"
           file_path: "CLAUDE.md"
           failure_message: "Missing"
@@ -2049,7 +2049,7 @@ rule_definitions:
         file_patterns: [".claude/skills/*/SKILL.md"]
         bundle_strategy: "individual"
       rules:
-        - rule_type: "regex_match"
+        - rule_type: "core:regex_match"
           description: "Skill should have examples"
           file_path: "SKILL.md"
           pattern: "## Examples"
@@ -2093,7 +2093,7 @@ rule_definitions:
         file_patterns: ["*.md"]
         bundle_strategy: "collection"
       rules:
-        - rule_type: "regex_match"
+        - rule_type: "core:regex_match"
           description: "Should have license section"
           file_path: "README.md"
           pattern: "## License"

--- a/tests/integration/test_failure_details_integration.py
+++ b/tests/integration/test_failure_details_integration.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import (
     ClaudeCircularDependenciesValidator,
@@ -102,7 +102,7 @@ class TestFailureDetailsIntegration:
         # Test circular dependency validator
         circular_validator = ClaudeCircularDependenciesValidator()
         circular_rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Circular dependency detected",
@@ -114,7 +114,7 @@ class TestFailureDetailsIntegration:
         # Test max depth validator
         depth_validator = ClaudeMaxDependencyDepthValidator()
         depth_rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Depth exceeded",
@@ -126,7 +126,7 @@ class TestFailureDetailsIntegration:
         # Test duplicate validator
         duplicate_validator = ClaudeDependencyDuplicateValidator()
         duplicate_rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check duplicates",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Duplicate detected",
@@ -154,7 +154,7 @@ class TestFailureDetailsIntegration:
             (
                 ClaudeCircularDependenciesValidator(),
                 ValidationRule(
-                    rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+                    rule_type="core:circular_dependencies",
                     description="Check circular dependencies",
                     params={"resource_dirs": [".claude/skills"]},
                     failure_message="Circular dependency",
@@ -166,7 +166,7 @@ class TestFailureDetailsIntegration:
             (
                 ClaudeMaxDependencyDepthValidator(),
                 ValidationRule(
-                    rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+                    rule_type="core:max_dependency_depth",
                     description="Check depth",
                     params={"resource_dirs": [".claude/skills"], "max_depth": 2},
                     failure_message="Depth exceeded",
@@ -178,7 +178,7 @@ class TestFailureDetailsIntegration:
             (
                 ClaudeDependencyDuplicateValidator(),
                 ValidationRule(
-                    rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+                    rule_type="core:dependency_duplicate",
                     description="Check duplicates",
                     params={"resource_dirs": [".claude/skills"]},
                     failure_message="Duplicate detected",
@@ -210,21 +210,21 @@ class TestFailureDetailsIntegration:
 
         rules = [
             ValidationRule(
-                rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+                rule_type="core:circular_dependencies",
                 description="Check circular",
                 params={"resource_dirs": [".claude/skills"]},
                 failure_message="Circular",
                 expected_behavior="No cycles",
             ),
             ValidationRule(
-                rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+                rule_type="core:max_dependency_depth",
                 description="Check depth",
                 params={"resource_dirs": [".claude/skills"], "max_depth": 2},
                 failure_message="Depth",
                 expected_behavior="Max 2",
             ),
             ValidationRule(
-                rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+                rule_type="core:dependency_duplicate",
                 description="Check dup",
                 params={"resource_dirs": [".claude/skills"]},
                 failure_message="Dup",
@@ -257,6 +257,8 @@ class TestFailureDetailsIntegration:
         class LegacyValidator(BaseValidator):
             """Validator that doesn't use failure_details."""
 
+            validation_type = "legacy:test"
+
             @property
             def computation_type(self):
                 return "programmatic"
@@ -278,7 +280,7 @@ class TestFailureDetailsIntegration:
 
         validator = LegacyValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Test",
             params={},
             failure_message="Test",
@@ -295,7 +297,7 @@ class TestFailureDetailsIntegration:
         """Test that failure_details is preserved when creating DocumentRule."""
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check circular",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Circular dependency",
@@ -318,7 +320,7 @@ class TestFailureDetailsIntegration:
         # Circular dependencies
         circular_validator = ClaudeCircularDependenciesValidator()
         circular_rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check circular",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -335,7 +337,7 @@ class TestFailureDetailsIntegration:
         # Max depth
         depth_validator = ClaudeMaxDependencyDepthValidator()
         depth_rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Depth exceeded",
@@ -355,6 +357,8 @@ class TestFailureDetailsIntegration:
 
         class MinimalValidator(BaseValidator):
             """Validator with minimal failure_details."""
+
+            validation_type = "minimal:test"
 
             @property
             def computation_type(self):
@@ -394,7 +398,7 @@ class TestFailureDetailsIntegration:
 
         validator = MinimalValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Test",
             params={},
             failure_message="Test message",
@@ -412,7 +416,7 @@ class TestFailureDetailsIntegration:
         # Test that placeholders in failure_message get replaced
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Depth {actual_depth} exceeds max {max_depth}",
@@ -438,21 +442,21 @@ class TestFailureDetailsIntegration:
 
         rules = [
             ValidationRule(
-                rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+                rule_type="core:circular_dependencies",
                 description="Check",
                 params={"resource_dirs": [".claude/skills"]},
                 failure_message="Issue",
                 expected_behavior="Expected",
             ),
             ValidationRule(
-                rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+                rule_type="core:max_dependency_depth",
                 description="Check",
                 params={"resource_dirs": [".claude/skills"], "max_depth": 2},
                 failure_message="Issue",
                 expected_behavior="Expected",
             ),
             ValidationRule(
-                rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+                rule_type="core:dependency_duplicate",
                 description="Check",
                 params={"resource_dirs": [".claude/skills"]},
                 failure_message="Issue",

--- a/tests/integration/test_new_validators_integration.py
+++ b/tests/integration/test_new_validators_integration.py
@@ -7,7 +7,6 @@ from drift.config.models import (
     DocumentBundleConfig,
     ValidationRule,
     ValidationRulesConfig,
-    ValidationType,
 )
 from drift.documents.loader import DocumentLoader
 from drift.validation.validators import ClaudeDependencyDuplicateValidator, MarkdownLinkValidator
@@ -99,7 +98,7 @@ Expert in code style and formatting standards.
             ),
             rules=[
                 ValidationRule(
-                    rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+                    rule_type="core:dependency_duplicate",
                     description="Check for duplicate skill dependencies",
                     failure_message="Found redundant skill dependencies",
                     expected_behavior=(
@@ -179,7 +178,7 @@ Also see [nonexistent](docs/does-not-exist.md).
             ),
             rules=[
                 ValidationRule(
-                    rule_type=ValidationType.MARKDOWN_LINK,
+                    rule_type="core:markdown_link",
                     description="Check for broken links in documentation",
                     failure_message="Found broken links",
                     expected_behavior="All links should point to existing files",
@@ -223,7 +222,7 @@ Also see [nonexistent](docs/does-not-exist.md).
             ),
             rules=[
                 ValidationRule(
-                    rule_type=ValidationType.MARKDOWN_LINK,
+                    rule_type="core:markdown_link",
                     description="Check for broken links",
                     failure_message="Found broken links",
                     expected_behavior="All links should be valid",
@@ -294,7 +293,7 @@ Missing [nonexistent file](does-not-exist.md).
             ),
             rules=[
                 ValidationRule(
-                    rule_type=ValidationType.MARKDOWN_LINK,
+                    rule_type="core:markdown_link",
                     description="Check for broken links",
                     failure_message="Found broken links",
                     expected_behavior="All links should be valid",
@@ -396,14 +395,14 @@ Check the [missing guide](guide.md).
             ),
             rules=[
                 ValidationRule(
-                    rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+                    rule_type="core:dependency_duplicate",
                     description="Check for duplicate dependencies",
                     failure_message="Found redundant dependencies",
                     expected_behavior="No transitive duplicates",
                     params={"resource_dirs": [".claude/commands", ".claude/skills"]},
                 ),
                 ValidationRule(
-                    rule_type=ValidationType.MARKDOWN_LINK,
+                    rule_type="core:markdown_link",
                     description="Check for broken links",
                     failure_message="Found broken links",
                     expected_behavior="All links should be valid",
@@ -426,9 +425,9 @@ Check the [missing guide](guide.md).
         all_results = []
         for bundle in bundles:
             for rule in validation_config.rules:
-                if rule.rule_type == ValidationType.DEPENDENCY_DUPLICATE:
+                if rule.rule_type == "core:dependency_duplicate":
                     result = dep_validator.validate(rule, bundle, bundles)
-                elif rule.rule_type == ValidationType.MARKDOWN_LINK:
+                elif rule.rule_type == "core:markdown_link":
                     result = link_validator.validate(rule, bundle, bundles)
                 else:
                     result = None

--- a/tests/integration/test_plugin_system.py
+++ b/tests/integration/test_plugin_system.py
@@ -1,0 +1,572 @@
+"""Integration tests for the custom validation plugin system."""
+
+from pathlib import Path
+from typing import List, Literal, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentRule
+from drift.validation.validators import BaseValidator, ValidatorRegistry
+
+
+class CustomSecurityValidator(BaseValidator):
+    """Custom security validator for testing plugin system."""
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "security:vulnerability_scan"
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type for this validator."""
+        return "programmatic"
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Scan for security vulnerabilities.
+
+        Checks if a 'vulnerabilities.txt' file exists in the project.
+        If it exists and is not empty, fails validation.
+        """
+        if not rule.file_path:
+            rule.file_path = "vulnerabilities.txt"
+
+        vuln_file = bundle.project_path / rule.file_path
+
+        if vuln_file.exists() and vuln_file.is_file():
+            content = vuln_file.read_text()
+            if content.strip():
+                # Found vulnerabilities
+                return DocumentRule(
+                    bundle_id=bundle.bundle_id,
+                    bundle_type=bundle.bundle_type,
+                    file_paths=[rule.file_path],
+                    observed_issue=rule.failure_message,
+                    expected_quality=rule.expected_behavior,
+                    rule_type="",
+                    context=f"Security scan found issues: {content[:100]}",
+                )
+
+        # No vulnerabilities found
+        return None
+
+
+class CustomComplianceValidator(BaseValidator):
+    """Custom compliance validator for testing."""
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "compliance:license_check"
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type for this validator."""
+        return "programmatic"
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Check for required license file."""
+        license_file = bundle.project_path / "LICENSE"
+
+        if not license_file.exists():
+            return DocumentRule(
+                bundle_id=bundle.bundle_id,
+                bundle_type=bundle.bundle_type,
+                file_paths=["LICENSE"],
+                observed_issue=rule.failure_message,
+                expected_quality=rule.expected_behavior,
+                rule_type="",
+                context="Compliance check: LICENSE file missing",
+            )
+
+        return None
+
+
+class TestPluginSystemEndToEnd:
+    """End-to-end tests for the plugin system."""
+
+    @pytest.fixture
+    def project_with_vulnerabilities(self, tmp_path):
+        """Create a project with security vulnerabilities."""
+        vuln_file = tmp_path / "vulnerabilities.txt"
+        vuln_file.write_text("SQL Injection in login.py\nXSS in profile.html")
+        return tmp_path
+
+    @pytest.fixture
+    def project_without_vulnerabilities(self, tmp_path):
+        """Create a project without security vulnerabilities."""
+        vuln_file = tmp_path / "vulnerabilities.txt"
+        vuln_file.write_text("")  # Empty file = no vulnerabilities
+        return tmp_path
+
+    @pytest.fixture
+    def project_without_license(self, tmp_path):
+        """Create a project without a LICENSE file."""
+        (tmp_path / "README.md").write_text("# Test Project")
+        return tmp_path
+
+    @pytest.fixture
+    def project_with_license(self, tmp_path):
+        """Create a project with a LICENSE file."""
+        (tmp_path / "LICENSE").write_text("MIT License")
+        return tmp_path
+
+    def test_load_and_execute_custom_security_validator(self, project_with_vulnerabilities):
+        """Test loading and executing a custom security validator plugin."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            # Mock the module containing the security validator
+            mock_module = MagicMock()
+            mock_module.SecurityValidator = CustomSecurityValidator
+            mock_import.return_value = mock_module
+
+            # Create bundle
+            bundle = DocumentBundle(
+                bundle_id="security-test",
+                bundle_type="project",
+                bundle_strategy="collection",
+                files=[],
+                project_path=project_with_vulnerabilities,
+            )
+
+            # Create validation rule
+            rule = ValidationRule(
+                rule_type="security:vulnerability_scan",
+                description="Scan for security vulnerabilities",
+                file_path="vulnerabilities.txt",
+                failure_message="Security vulnerabilities detected",
+                expected_behavior="No security vulnerabilities",
+            )
+
+            # Execute validation with plugin
+            result = registry.execute_rule(
+                rule=rule,
+                bundle=bundle,
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            # Should fail because vulnerabilities exist
+            assert result is not None
+            assert result.observed_issue == "Security vulnerabilities detected"
+            assert "vulnerabilities.txt" in result.file_paths
+
+    def test_custom_validator_passes_when_no_issues(self, project_without_vulnerabilities):
+        """Test that custom validator passes when no issues found."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.SecurityValidator = CustomSecurityValidator
+            mock_import.return_value = mock_module
+
+            bundle = DocumentBundle(
+                bundle_id="security-test",
+                bundle_type="project",
+                bundle_strategy="collection",
+                files=[],
+                project_path=project_without_vulnerabilities,
+            )
+
+            rule = ValidationRule(
+                rule_type="security:vulnerability_scan",
+                description="Scan for security vulnerabilities",
+                file_path="vulnerabilities.txt",
+                failure_message="Security vulnerabilities detected",
+                expected_behavior="No security vulnerabilities",
+            )
+
+            result = registry.execute_rule(
+                rule=rule,
+                bundle=bundle,
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            # Should pass because no vulnerabilities
+            assert result is None
+
+    def test_multiple_custom_validators(
+        self, project_with_vulnerabilities, project_without_license
+    ):
+        """Test using multiple custom validators in the same registry."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            # Setup mock to return different validators based on provider
+            def mock_import_side_effect(module_path):
+                mock_module = MagicMock()
+                if "security_package" in module_path:
+                    mock_module.SecurityValidator = CustomSecurityValidator
+                elif "compliance_package" in module_path:
+                    mock_module.ComplianceValidator = CustomComplianceValidator
+                return mock_module
+
+            mock_import.side_effect = mock_import_side_effect
+
+            # Combine both project issues for testing
+            combined_project = project_without_license
+            (combined_project / "vulnerabilities.txt").write_text("SQL Injection")
+
+            bundle = DocumentBundle(
+                bundle_id="combined-test",
+                bundle_type="project",
+                bundle_strategy="collection",
+                files=[],
+                project_path=combined_project,
+            )
+
+            # Test security validator
+            security_rule = ValidationRule(
+                rule_type="security:vulnerability_scan",
+                description="Security scan",
+                failure_message="Security issues found",
+                expected_behavior="No security issues",
+            )
+
+            security_result = registry.execute_rule(
+                rule=security_rule,
+                bundle=bundle,
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            # Test compliance validator
+            compliance_rule = ValidationRule(
+                rule_type="compliance:license_check",
+                description="License check",
+                failure_message="LICENSE file missing",
+                expected_behavior="LICENSE file should exist",
+            )
+
+            compliance_result = registry.execute_rule(
+                rule=compliance_rule,
+                bundle=bundle,
+                provider="compliance_package.validators:ComplianceValidator",
+            )
+
+            # Both should fail
+            assert security_result is not None
+            assert compliance_result is not None
+
+    def test_mixing_builtin_and_custom_validators(self, project_without_license):
+        """Test mixing built-in core: validators with custom plugin validators."""
+        registry = ValidatorRegistry()
+
+        # Create a README.md file
+        (project_without_license / "README.md").write_text("# Test")
+
+        bundle = DocumentBundle(
+            bundle_id="mixed-test",
+            bundle_type="project",
+            bundle_strategy="collection",
+            files=[],
+            project_path=project_without_license,
+        )
+
+        # Test built-in core:file_exists validator
+        builtin_rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check README exists",
+            file_path="README.md",
+            failure_message="README.md not found",
+            expected_behavior="README.md should exist",
+        )
+
+        builtin_result = registry.execute_rule(rule=builtin_rule, bundle=bundle)
+
+        # Test custom compliance validator
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.ComplianceValidator = CustomComplianceValidator
+            mock_import.return_value = mock_module
+
+            custom_rule = ValidationRule(
+                rule_type="compliance:license_check",
+                description="License check",
+                failure_message="LICENSE file missing",
+                expected_behavior="LICENSE file should exist",
+            )
+
+            custom_result = registry.execute_rule(
+                rule=custom_rule,
+                bundle=bundle,
+                provider="compliance_package.validators:ComplianceValidator",
+            )
+
+        # Built-in should pass (README exists)
+        assert builtin_result is None
+
+        # Custom should fail (LICENSE doesn't exist)
+        assert custom_result is not None
+
+    def test_plugin_validator_receives_correct_parameters(self):
+        """Test that plugin validators receive correct parameters."""
+
+        class ParameterTrackingValidator(BaseValidator):
+            """Validator that tracks what parameters it receives."""
+
+            received_params = {}
+
+            @property
+            def validation_type(self) -> str:
+                return "test:param_tracker"
+
+            @property
+            def computation_type(self) -> Literal["programmatic", "llm"]:
+                return "programmatic"
+
+            def validate(
+                self,
+                rule: ValidationRule,
+                bundle: DocumentBundle,
+                all_bundles: Optional[List[DocumentBundle]] = None,
+            ) -> Optional[DocumentRule]:
+                # Track received parameters
+                ParameterTrackingValidator.received_params = {
+                    "rule_type": rule.rule_type,
+                    "rule_description": rule.description,
+                    "bundle_id": bundle.bundle_id,
+                    "all_bundles_count": len(all_bundles) if all_bundles else 0,
+                }
+                return None
+
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.ParamValidator = ParameterTrackingValidator
+            mock_import.return_value = mock_module
+
+            bundle = DocumentBundle(
+                bundle_id="param-test-bundle",
+                bundle_type="test",
+                bundle_strategy="collection",
+                files=[],
+                project_path=Path("/tmp"),
+            )
+
+            rule = ValidationRule(
+                rule_type="test:param_tracker",
+                description="Test parameter passing",
+                failure_message="Test failed",
+                expected_behavior="Test passed",
+            )
+
+            other_bundle = DocumentBundle(
+                bundle_id="other-bundle",
+                bundle_type="test",
+                bundle_strategy="collection",
+                files=[],
+                project_path=Path("/tmp"),
+            )
+
+            # Execute with all_bundles
+            registry.execute_rule(
+                rule=rule,
+                bundle=bundle,
+                all_bundles=[bundle, other_bundle],
+                provider="test_package:ParamValidator",
+            )
+
+            # Check parameters were received correctly
+            assert ParameterTrackingValidator.received_params["rule_type"] == "test:param_tracker"
+            assert (
+                ParameterTrackingValidator.received_params["rule_description"]
+                == "Test parameter passing"
+            )
+            assert ParameterTrackingValidator.received_params["bundle_id"] == "param-test-bundle"
+            assert ParameterTrackingValidator.received_params["all_bundles_count"] == 2
+
+    def test_plugin_computation_type_query(self):
+        """Test querying computation type for plugin validators."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.SecurityValidator = CustomSecurityValidator
+            mock_import.return_value = mock_module
+
+            # Query computation type (this will load the plugin)
+            comp_type = registry.get_computation_type(
+                "security:vulnerability_scan",
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            assert comp_type == "programmatic"
+
+            # Query is_programmatic
+            is_prog = registry.is_programmatic(
+                "security:vulnerability_scan",
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            assert is_prog is True
+
+
+class TestPluginErrorHandling:
+    """Test error handling in the plugin system."""
+
+    def test_plugin_validation_error_propagates(self, tmp_path):
+        """Test that validation errors from plugins propagate correctly."""
+
+        class ErrorValidator(BaseValidator):
+            """Validator that raises an error during validation."""
+
+            @property
+            def validation_type(self) -> str:
+                return "test:error"
+
+            @property
+            def computation_type(self) -> Literal["programmatic", "llm"]:
+                return "programmatic"
+
+            def validate(
+                self,
+                rule: ValidationRule,
+                bundle: DocumentBundle,
+                all_bundles: Optional[List[DocumentBundle]] = None,
+            ) -> Optional[DocumentRule]:
+                raise ValueError("Simulated validation error")
+
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.ErrorValidator = ErrorValidator
+            mock_import.return_value = mock_module
+
+            bundle = DocumentBundle(
+                bundle_id="error-test",
+                bundle_type="test",
+                bundle_strategy="collection",
+                files=[],
+                project_path=tmp_path,
+            )
+
+            rule = ValidationRule(
+                rule_type="test:error",
+                description="Error test",
+                failure_message="Failed",
+                expected_behavior="Should pass",
+            )
+
+            # Error should propagate
+            with pytest.raises(ValueError, match="Simulated validation error"):
+                registry.execute_rule(
+                    rule=rule,
+                    bundle=bundle,
+                    provider="test_package:ErrorValidator",
+                )
+
+    def test_plugin_missing_required_property(self):
+        """Test error when plugin is missing required property."""
+
+        class IncompleteValidator:
+            """Validator missing required properties."""
+
+            def __init__(self, loader=None):
+                pass
+
+            def validate(self, rule, bundle, all_bundles=None):
+                return None
+
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.IncompleteValidator = IncompleteValidator
+            mock_import.return_value = mock_module
+
+            # Should fail because IncompleteValidator doesn't inherit from BaseValidator
+            with pytest.raises(TypeError, match="must inherit from BaseValidator"):
+                registry._load_validator(
+                    provider="test_package:IncompleteValidator",
+                    validation_type="test:incomplete",
+                )
+
+
+class TestPluginCaching:
+    """Test plugin caching behavior."""
+
+    def test_plugin_loaded_once_and_cached(self):
+        """Test that plugins are loaded once and cached for reuse."""
+        # Clear the cache before testing
+        ValidatorRegistry._loaded_plugins.clear()
+
+        registry = ValidatorRegistry()
+        load_count = 0
+
+        def counting_import(module_path):
+            nonlocal load_count
+            load_count += 1
+            mock_module = MagicMock()
+            mock_module.SecurityValidator = CustomSecurityValidator
+            return mock_module
+
+        with patch("importlib.import_module", side_effect=counting_import):
+            # First call - should import
+            registry.get_computation_type(
+                "security:vulnerability_scan",
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            # Second call - should use cache
+            registry.get_computation_type(
+                "security:vulnerability_scan",
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            # Third call - should use cache
+            registry.is_programmatic(
+                "security:vulnerability_scan",
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            # Should only import once
+            assert load_count == 1
+
+    def test_different_plugins_loaded_separately(self):
+        """Test that different plugins are loaded separately."""
+        # Clear the cache before testing
+        ValidatorRegistry._loaded_plugins.clear()
+
+        registry = ValidatorRegistry()
+        loaded_modules = set()
+
+        def tracking_import(module_path):
+            loaded_modules.add(module_path)
+            mock_module = MagicMock()
+            if "security" in module_path:
+                mock_module.SecurityValidator = CustomSecurityValidator
+            else:
+                mock_module.ComplianceValidator = CustomComplianceValidator
+            return mock_module
+
+        with patch("importlib.import_module", side_effect=tracking_import):
+            # Load security validator
+            registry.get_computation_type(
+                "security:vulnerability_scan",
+                provider="security_package.validators:SecurityValidator",
+            )
+
+            # Load compliance validator
+            registry.get_computation_type(
+                "compliance:license_check",
+                provider="compliance_package.validators:ComplianceValidator",
+            )
+
+            # Both should be loaded
+            assert len(loaded_modules) == 2
+            assert "security_package.validators" in loaded_modules
+            assert "compliance_package.validators" in loaded_modules

--- a/tests/integration/test_plugin_system_e2e.py
+++ b/tests/integration/test_plugin_system_e2e.py
@@ -1,0 +1,413 @@
+"""True end-to-end test for custom validation plugin system.
+
+This test creates an actual Python package in a temporary directory,
+adds it to sys.path, and loads it as a real 3rd party plugin without mocks.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle
+from drift.validation.validators import ValidatorRegistry
+
+
+@pytest.fixture
+def plugin_package(tmp_path):
+    """Create a real 3rd party plugin package in a temporary directory.
+
+    This creates:
+        my_security_plugin/
+            __init__.py
+            validators.py  (contains SecurityScanValidator)
+    """
+    # Create package directory
+    package_dir = tmp_path / "my_security_plugin"
+    package_dir.mkdir()
+
+    # Create __init__.py
+    init_file = package_dir / "__init__.py"
+    init_file.write_text('"""My custom security validation plugin."""\n')
+
+    # Create validators.py with a real validator
+    validators_file = package_dir / "validators.py"
+    validators_file.write_text(
+        '''"""Custom security validators."""
+
+from typing import List, Literal, Optional
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentRule
+from drift.validation.validators.base import BaseValidator
+
+
+class SecurityScanValidator(BaseValidator):
+    """Custom security scanner that checks for common issues."""
+
+    validation_type = "security:vulnerability_scan"
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type."""
+        return "programmatic"
+
+    @property
+    def supported_clients(self) -> List[str]:
+        """Return supported client types."""
+        return ["all"]
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Check for security vulnerabilities.
+
+        Looks for a vulnerabilities.txt file. If it exists and contains
+        content, validation fails.
+        """
+        vuln_file = bundle.project_path / "vulnerabilities.txt"
+
+        if vuln_file.exists() and vuln_file.is_file():
+            content = vuln_file.read_text().strip()
+            if content:
+                # Found vulnerabilities - return failure
+                vulns = content.split("\\n")
+                return DocumentRule(
+                    bundle_id=bundle.bundle_id,
+                    bundle_type=bundle.bundle_type,
+                    file_paths=["vulnerabilities.txt"],
+                    observed_issue=f"Security scan failed: {content}",
+                    expected_quality=rule.expected_behavior,
+                    rule_type=rule.rule_type,
+                    context=f"Found {len(vulns)} vulnerabilities",
+                    failure_details={"vulnerabilities_found": vulns},
+                )
+
+        # No vulnerabilities found - validation passes
+        return None
+
+
+class ComplianceValidator(BaseValidator):
+    """Custom compliance checker."""
+
+    validation_type = "security:compliance_check"
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type."""
+        return "programmatic"
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Check for required compliance files."""
+        required_files = rule.params.get("required_files", ["LICENSE", "SECURITY.md"])
+
+        missing = []
+        for filename in required_files:
+            if not (bundle.project_path / filename).exists():
+                missing.append(filename)
+
+        if missing:
+            return DocumentRule(
+                bundle_id=bundle.bundle_id,
+                bundle_type=bundle.bundle_type,
+                file_paths=missing,
+                observed_issue=f"Missing required compliance files: {', '.join(missing)}",
+                expected_quality=rule.expected_behavior,
+                rule_type=rule.rule_type,
+                context=f"Missing {len(missing)} compliance files",
+                failure_details={"missing_files": missing},
+            )
+
+        return None
+'''
+    )
+
+    # Add the parent directory to sys.path so we can import the package
+    sys.path.insert(0, str(tmp_path))
+
+    yield package_dir
+
+    # Cleanup: remove from sys.path
+    if str(tmp_path) in sys.path:
+        sys.path.remove(str(tmp_path))
+
+
+@pytest.fixture
+def vulnerable_project(tmp_path):
+    """Create a test project with security vulnerabilities."""
+    project_dir = tmp_path / "test_project"
+    project_dir.mkdir()
+
+    # Create vulnerabilities file
+    vuln_file = project_dir / "vulnerabilities.txt"
+    vuln_file.write_text(
+        "SQL Injection in auth.py line 42\n"
+        "XSS vulnerability in templates/profile.html\n"
+        "Hardcoded credentials in config.py"
+    )
+
+    return project_dir
+
+
+@pytest.fixture
+def secure_project(tmp_path):
+    """Create a test project without security vulnerabilities."""
+    project_dir = tmp_path / "secure_project"
+    project_dir.mkdir()
+
+    # Create empty vulnerabilities file (or no file at all)
+    vuln_file = project_dir / "vulnerabilities.txt"
+    vuln_file.write_text("")
+
+    return project_dir
+
+
+@pytest.fixture
+def non_compliant_project(tmp_path):
+    """Create a project missing compliance files."""
+    project_dir = tmp_path / "non_compliant_project"
+    project_dir.mkdir()
+
+    # Create a README but no LICENSE or SECURITY.md
+    (project_dir / "README.md").write_text("# Test Project")
+
+    return project_dir
+
+
+class TestRealPluginE2E:
+    """True end-to-end tests with real plugin loading (no mocks)."""
+
+    def test_load_real_plugin_and_detect_vulnerabilities(self, plugin_package, vulnerable_project):
+        """E2E: Load a real plugin package and execute validation.
+
+        This test:
+        1. Creates a real Python package with a validator
+        2. Adds it to sys.path
+        3. Loads it via ValidatorRegistry WITHOUT mocks
+        4. Executes validation on a real project directory
+        """
+        registry = ValidatorRegistry()
+
+        # Create a bundle representing the vulnerable project
+        bundle = DocumentBundle(
+            bundle_id="vulnerable-project",
+            bundle_type="project",
+            bundle_strategy="collection",
+            files=[],
+            project_path=vulnerable_project,
+        )
+
+        # Create validation rule that uses our custom plugin
+        rule = ValidationRule(
+            rule_type="security:vulnerability_scan",
+            description="Scan for security vulnerabilities using custom plugin",
+            failure_message="Security vulnerabilities detected by scanner",
+            expected_behavior="No security vulnerabilities should exist",
+        )
+
+        # Execute validation - this will ACTUALLY import the plugin
+        result = registry.execute_rule(
+            rule=rule,
+            bundle=bundle,
+            provider="my_security_plugin.validators:SecurityScanValidator",
+        )
+
+        # Assertions
+        assert result is not None, "Should detect vulnerabilities"
+        assert result.bundle_id == "vulnerable-project"
+        assert "SQL Injection" in result.observed_issue
+        assert result.failure_details is not None
+        assert "vulnerabilities_found" in result.failure_details
+
+    def test_load_real_plugin_passes_on_secure_project(self, plugin_package, secure_project):
+        """E2E: Plugin validation passes on secure project."""
+        registry = ValidatorRegistry()
+
+        bundle = DocumentBundle(
+            bundle_id="secure-project",
+            bundle_type="project",
+            bundle_strategy="collection",
+            files=[],
+            project_path=secure_project,
+        )
+
+        rule = ValidationRule(
+            rule_type="security:vulnerability_scan",
+            description="Security scan",
+            failure_message="Vulnerabilities found",
+            expected_behavior="No vulnerabilities",
+        )
+
+        # Execute validation - loads real plugin
+        result = registry.execute_rule(
+            rule=rule,
+            bundle=bundle,
+            provider="my_security_plugin.validators:SecurityScanValidator",
+        )
+
+        # Should pass (no vulnerabilities)
+        assert result is None
+
+    def test_load_multiple_validators_from_same_package(
+        self, plugin_package, non_compliant_project
+    ):
+        """E2E: Load multiple validators from the same plugin package."""
+        registry = ValidatorRegistry()
+
+        # Add some files to the project
+        (non_compliant_project / "vulnerabilities.txt").write_text("XSS in app.py")
+
+        bundle = DocumentBundle(
+            bundle_id="non-compliant",
+            bundle_type="project",
+            bundle_strategy="collection",
+            files=[],
+            project_path=non_compliant_project,
+        )
+
+        # Test first validator - security scan
+        security_rule = ValidationRule(
+            rule_type="security:vulnerability_scan",
+            description="Security scan",
+            failure_message="Security issues",
+            expected_behavior="No issues",
+        )
+
+        security_result = registry.execute_rule(
+            rule=security_rule,
+            bundle=bundle,
+            provider="my_security_plugin.validators:SecurityScanValidator",
+        )
+
+        # Test second validator from SAME package - compliance check
+        compliance_rule = ValidationRule(
+            rule_type="security:compliance_check",
+            description="Compliance check",
+            failure_message="Missing compliance files",
+            expected_behavior="All compliance files present",
+            params={"required_files": ["LICENSE", "SECURITY.md"]},
+        )
+
+        compliance_result = registry.execute_rule(
+            rule=compliance_rule,
+            bundle=bundle,
+            provider="my_security_plugin.validators:ComplianceValidator",
+        )
+
+        # Both should fail
+        assert security_result is not None, "Should detect security issue"
+        assert compliance_result is not None, "Should detect missing compliance files"
+        assert "LICENSE" in compliance_result.observed_issue
+        assert "SECURITY.md" in compliance_result.observed_issue
+
+    def test_plugin_caching_works_correctly(self, plugin_package, secure_project):
+        """E2E: Verify that loaded plugins are cached correctly."""
+        registry = ValidatorRegistry()
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="project",
+            bundle_strategy="collection",
+            files=[],
+            project_path=secure_project,
+        )
+
+        rule = ValidationRule(
+            rule_type="security:vulnerability_scan",
+            description="Security scan",
+            failure_message="Issues found",
+            expected_behavior="No issues",
+        )
+
+        # Load plugin first time
+        result1 = registry.execute_rule(
+            rule=rule,
+            bundle=bundle,
+            provider="my_security_plugin.validators:SecurityScanValidator",
+        )
+
+        # Load same plugin second time - should use cache
+        result2 = registry.execute_rule(
+            rule=rule,
+            bundle=bundle,
+            provider="my_security_plugin.validators:SecurityScanValidator",
+        )
+
+        # Both should work and return None (passing)
+        assert result1 is None
+        assert result2 is None
+
+        # Verify plugin is in cache
+        cache_key = (
+            "security:vulnerability_scan:my_security_plugin.validators:SecurityScanValidator"
+        )
+        assert cache_key in registry._loaded_plugins
+
+    def test_plugin_error_handling_module_not_found(self):
+        """E2E: Test error handling when plugin module doesn't exist."""
+        registry = ValidatorRegistry()
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="project",
+            bundle_strategy="collection",
+            files=[],
+            project_path=Path("/tmp"),
+        )
+
+        rule = ValidationRule(
+            rule_type="fake:validator",
+            description="Test",
+            failure_message="Failed",
+            expected_behavior="Pass",
+        )
+
+        # Try to load non-existent plugin
+        with pytest.raises(ModuleNotFoundError) as exc_info:
+            registry.execute_rule(
+                rule=rule,
+                bundle=bundle,
+                provider="nonexistent_package.validators:FakeValidator",
+            )
+
+        assert "Provider module not found" in str(exc_info.value)
+        assert "nonexistent_package" in str(exc_info.value)
+
+    def test_plugin_error_handling_class_not_found(self, plugin_package):
+        """E2E: Test error handling when class doesn't exist in module."""
+        registry = ValidatorRegistry()
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="project",
+            bundle_strategy="collection",
+            files=[],
+            project_path=Path("/tmp"),
+        )
+
+        rule = ValidationRule(
+            rule_type="fake:validator",
+            description="Test",
+            failure_message="Failed",
+            expected_behavior="Pass",
+        )
+
+        # Try to load non-existent class from existing module
+        with pytest.raises(AttributeError) as exc_info:
+            registry.execute_rule(
+                rule=rule,
+                bundle=bundle,
+                provider="my_security_plugin.validators:NonExistentValidator",
+            )
+
+        assert "Provider class not found" in str(exc_info.value)
+        assert "NonExistentValidator" in str(exc_info.value)

--- a/tests/integration/test_rule_validation.py
+++ b/tests/integration/test_rule_validation.py
@@ -13,7 +13,6 @@ from drift.config.models import (
     RuleDefinition,
     ValidationRule,
     ValidationRulesConfig,
-    ValidationType,
 )
 from drift.core.analyzer import DriftAnalyzer
 
@@ -78,7 +77,7 @@ class TestRuleBasedValidation:
             phases=[
                 PhaseDefinition(
                     name="check_file",
-                    type="file_exists",
+                    type="core:file_exists",
                     file_path="CLAUDE.md",
                     failure_message="CLAUDE.md not found",
                     expected_behavior="CLAUDE.md should exist",
@@ -113,7 +112,7 @@ class TestRuleBasedValidation:
             phases=[
                 PhaseDefinition(
                     name="check_file",
-                    type="file_exists",
+                    type="core:file_exists",
                     file_path="MISSING.md",
                     failure_message="MISSING.md not found",
                     expected_behavior="MISSING.md should exist",
@@ -147,20 +146,22 @@ class TestRuleBasedValidation:
             scope="project_level",
             context="Testing inverted logic",
             requires_project_context=True,
-            document_bundle=DocumentBundleConfig(
-                bundle_type="configuration",
-                file_patterns=["CLAUDE.md"],
-                bundle_strategy=BundleStrategy.COLLECTION,
+            validation_rules=ValidationRulesConfig(
+                document_bundle=DocumentBundleConfig(
+                    bundle_type="configuration",
+                    file_patterns=["CLAUDE.md"],
+                    bundle_strategy=BundleStrategy.COLLECTION,
+                ),
+                rules=[
+                    ValidationRule(
+                        rule_type="core:file_not_exists",
+                        description="CLAUDE.md must not exist",
+                        file_path="CLAUDE.md",
+                        failure_message="CLAUDE.md exists but should not",
+                        expected_behavior="CLAUDE.md should be absent",
+                    )
+                ],
             ),
-            phases=[
-                PhaseDefinition(
-                    name="check_file",
-                    type="file_not_exists",
-                    file_path="CLAUDE.md",
-                    failure_message="CLAUDE.md exists but should not",
-                    expected_behavior="CLAUDE.md should be absent",
-                )
-            ],
         )
 
         base_config.rule_definitions["claude_not_exist"] = learning_type_config
@@ -195,7 +196,7 @@ class TestRuleBasedValidation:
                 ),
                 rules=[
                     ValidationRule(
-                        rule_type=ValidationType.FILE_EXISTS,
+                        rule_type="core:file_exists",
                         description="At least one skill must exist",
                         file_path=".claude/skills/*/SKILL.md",
                         failure_message="No skill files found",
@@ -233,21 +234,21 @@ class TestRuleBasedValidation:
                 ),
                 rules=[
                     ValidationRule(
-                        rule_type=ValidationType.FILE_EXISTS,
+                        rule_type="core:file_exists",
                         description="README must exist",
                         file_path="README.md",
                         failure_message="README.md not found",
                         expected_behavior="README.md should exist",
                     ),
                     ValidationRule(
-                        rule_type=ValidationType.FILE_EXISTS,
+                        rule_type="core:file_exists",
                         description="CLAUDE must exist",
                         file_path="CLAUDE.md",
                         failure_message="CLAUDE.md not found",
                         expected_behavior="CLAUDE.md should exist",
                     ),
                     ValidationRule(
-                        rule_type=ValidationType.FILE_EXISTS,
+                        rule_type="core:file_exists",
                         description="MISSING check (will fail)",
                         file_path="MISSING.md",
                         failure_message="MISSING.md not found",

--- a/tests/unit/test_analyze_command.py
+++ b/tests/unit/test_analyze_command.py
@@ -41,6 +41,7 @@ class TestMergeResults:
                 total_conversations=1,
                 total_rule_violations=2,
                 by_type={"incomplete_work": 2},
+                by_group={"Workflow": 2},
             ),
             results=[],
         )
@@ -50,6 +51,7 @@ class TestMergeResults:
                 total_conversations=0,
                 total_rule_violations=1,
                 by_type={"claude_md_missing": 1},
+                by_group={"Documentation": 1},
             ),
             results=[],
         )
@@ -59,6 +61,8 @@ class TestMergeResults:
         assert merged.summary.total_rule_violations == 3
         assert merged.summary.by_type["incomplete_work"] == 2
         assert merged.summary.by_type["claude_md_missing"] == 1
+        assert merged.summary.by_group["Workflow"] == 2
+        assert merged.summary.by_group["Documentation"] == 1
 
     def test_merge_by_type_with_overlapping_types(self):
         """Test merging when both results have the same learning type."""
@@ -68,6 +72,7 @@ class TestMergeResults:
                 total_conversations=1,
                 total_rule_violations=2,
                 by_type={"incomplete_work": 2},
+                by_group={"Workflow": 2},
             ),
             results=[],
         )
@@ -77,6 +82,7 @@ class TestMergeResults:
                 total_conversations=0,
                 total_rule_violations=3,
                 by_type={"incomplete_work": 3},
+                by_group={"Workflow": 3},
             ),
             results=[],
         )
@@ -85,6 +91,7 @@ class TestMergeResults:
 
         assert merged.summary.total_rule_violations == 5
         assert merged.summary.by_type["incomplete_work"] == 5
+        assert merged.summary.by_group["Workflow"] == 5
 
     def test_merge_document_learnings_metadata(self):
         """Test that document_rules metadata is preserved."""

--- a/tests/unit/test_analyzer.py
+++ b/tests/unit/test_analyzer.py
@@ -202,6 +202,9 @@ class TestDriftAnalyzer:
         assert summary.conversations_without_drift == 1
         assert "incomplete_work" in summary.by_type
         assert summary.by_type["incomplete_work"] == 1
+        # Check by_group (sample_learning has no group_name, so defaults to "General")
+        assert "General" in summary.by_group
+        assert summary.by_group["General"] == 1
 
     @patch("drift.core.analyzer.ClaudeCodeLoader")
     @patch("drift.core.analyzer.BedrockProvider")
@@ -1179,7 +1182,7 @@ class TestDriftAnalyzer:
             phases=[
                 PhaseDefinition(
                     name="check",
-                    type="file_exists",
+                    type="core:file_exists",
                     prompt="",
                     model="haiku",
                     available_resources=[],
@@ -1385,7 +1388,6 @@ class TestDriftAnalyzer:
             DocumentBundleConfig,
             ValidationRule,
             ValidationRulesConfig,
-            ValidationType,
         )
         from drift.core.types import DocumentBundle, DocumentFile
 
@@ -1393,7 +1395,7 @@ class TestDriftAnalyzer:
         validation_config = ValidationRulesConfig(
             rules=[
                 ValidationRule(
-                    rule_type=ValidationType.FILE_EXISTS,
+                    rule_type="core:file_exists",
                     description="Test rule",
                     file_path="nonexistent.txt",
                     failure_message="Failed",
@@ -1459,7 +1461,7 @@ class TestDriftAnalyzer:
             phases=[
                 PhaseDefinition(
                     name="check_file",
-                    type="file_exists",
+                    type="core:file_exists",
                     file_path="test.md",
                     failure_message="Test file not found",
                     expected_behavior="Test file should exist",
@@ -1509,7 +1511,7 @@ class TestDriftAnalyzer:
             phases=[
                 PhaseDefinition(
                     name="check_missing_file",
-                    type="file_exists",
+                    type="core:file_exists",
                     file_path="nonexistent.md",
                     failure_message="File not found",
                     expected_behavior="File should exist",
@@ -1609,7 +1611,6 @@ class TestDriftAnalyzer:
             DocumentBundleConfig,
             ValidationRule,
             ValidationRulesConfig,
-            ValidationType,
         )
         from drift.core.types import DocumentBundle, DocumentFile
 
@@ -1617,7 +1618,7 @@ class TestDriftAnalyzer:
         validation_config = ValidationRulesConfig(
             rules=[
                 ValidationRule(
-                    rule_type=ValidationType.REGEX_MATCH,
+                    rule_type="core:regex_match",
                     description="Test rule",
                     file_path="test.md",
                     pattern=".*",  # Valid pattern

--- a/tests/unit/test_analyzer_execution_details.py
+++ b/tests/unit/test_analyzer_execution_details.py
@@ -40,7 +40,7 @@ class TestAnalyzerExecutionDetails:
                             ),
                             rules=[
                                 ValidationRule(
-                                    rule_type="file_exists",
+                                    rule_type="core:file_exists",
                                     description="Validates .claude.md exists",
                                     file_path=".claude.md",
                                     failure_message="Missing .claude.md",
@@ -95,7 +95,7 @@ class TestAnalyzerExecutionDetails:
             assert "validation_results" in detail
             validation = detail["validation_results"]
             assert "rule_type" in validation
-            assert validation["rule_type"] == "file_exists"
+            assert validation["rule_type"] == "core:file_exists"
 
     def test_analyze_documents_returns_execution_details_for_failed_rule(self):
         """Test that analyze_documents returns execution_details when a rule fails."""
@@ -119,7 +119,7 @@ class TestAnalyzerExecutionDetails:
                             ),
                             rules=[
                                 ValidationRule(
-                                    rule_type="file_exists",
+                                    rule_type="core:file_exists",
                                     description="Validates .claude.md exists",
                                     file_path=".claude.md",
                                     failure_message="Missing .claude.md",
@@ -180,7 +180,7 @@ class TestAnalyzerExecutionDetails:
                             ),
                             rules=[
                                 ValidationRule(
-                                    rule_type="file_exists",
+                                    rule_type="core:file_exists",
                                     description="Validates .claude.md exists",
                                     file_path=".claude.md",
                                     failure_message="Missing",

--- a/tests/unit/test_analyzer_summary_counts.py
+++ b/tests/unit/test_analyzer_summary_counts.py
@@ -45,7 +45,7 @@ def test_summary_counts_consistency_with_severity():
                         ),
                         rules=[
                             ValidationRule(
-                                rule_type="file_exists",
+                                rule_type="core:file_exists",
                                 description="Check file2.md exists",
                                 file_path="file2.md",
                                 failure_message="file2.md missing",
@@ -68,7 +68,7 @@ def test_summary_counts_consistency_with_severity():
                         ),
                         rules=[
                             ValidationRule(
-                                rule_type="file_exists",
+                                rule_type="core:file_exists",
                                 description="Check file3.md exists",
                                 file_path="file3.md",
                                 failure_message="file3.md missing",
@@ -91,7 +91,7 @@ def test_summary_counts_consistency_with_severity():
                         ),
                         rules=[
                             ValidationRule(
-                                rule_type="file_exists",
+                                rule_type="core:file_exists",
                                 description="Check file5.md exists",
                                 file_path="file5.md",
                                 failure_message="file5.md missing",
@@ -114,7 +114,7 @@ def test_summary_counts_consistency_with_severity():
                         ),
                         rules=[
                             ValidationRule(
-                                rule_type="file_exists",
+                                rule_type="core:file_exists",
                                 description="Check file4.md exists",
                                 file_path="file4.md",
                                 failure_message="file4.md missing",
@@ -221,7 +221,7 @@ def test_summary_counts_math_consistency():
                         ),
                         rules=[
                             ValidationRule(
-                                rule_type="file_exists",
+                                rule_type="core:file_exists",
                                 description="Check file1.md exists",
                                 file_path="file1.md",
                                 failure_message="file1.md missing",
@@ -244,7 +244,7 @@ def test_summary_counts_math_consistency():
                         ),
                         rules=[
                             ValidationRule(
-                                rule_type="file_exists",
+                                rule_type="core:file_exists",
                                 description="Check file2.md exists",
                                 file_path="file2.md",
                                 failure_message="file2.md missing",
@@ -267,7 +267,7 @@ def test_summary_counts_math_consistency():
                         ),
                         rules=[
                             ValidationRule(
-                                rule_type="file_exists",
+                                rule_type="core:file_exists",
                                 description="Check file3.md exists",
                                 file_path="file3.md",
                                 failure_message="file3.md missing",

--- a/tests/unit/test_base_validator_format_message.py
+++ b/tests/unit/test_base_validator_format_message.py
@@ -8,6 +8,8 @@ from drift.validation.validators.base import BaseValidator
 class ConcreteValidator(BaseValidator):
     """Concrete implementation of BaseValidator for testing."""
 
+    validation_type = "test:concrete"
+
     @property
     def computation_type(self):
         """Return computation type."""

--- a/tests/unit/test_circular_dependencies_failure_details.py
+++ b/tests/unit/test_circular_dependencies_failure_details.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeCircularDependenciesValidator
 
@@ -19,7 +19,7 @@ class TestCircularDependenciesValidatorFailureDetails:
     def validation_rule(self):
         """Create standard validation rule."""
         return ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Circular dependency detected",

--- a/tests/unit/test_circular_dependencies_validator.py
+++ b/tests/unit/test_circular_dependencies_validator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeCircularDependenciesValidator
 
@@ -107,7 +107,7 @@ class TestCircularDependenciesValidator:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -143,7 +143,7 @@ class TestCircularDependenciesValidator:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -178,7 +178,7 @@ class TestCircularDependenciesValidator:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -229,7 +229,7 @@ class TestCircularDependenciesValidator:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -264,7 +264,7 @@ class TestCircularDependenciesValidator:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -293,7 +293,7 @@ class TestCircularDependenciesValidator:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={},  # Missing resource_dirs
             failure_message="Found circular dependency",
@@ -327,7 +327,7 @@ class TestCircularDependenciesValidator:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",

--- a/tests/unit/test_circular_dependencies_validator_additional.py
+++ b/tests/unit/test_circular_dependencies_validator_additional.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeCircularDependenciesValidator
 
@@ -40,7 +40,7 @@ class TestCircularDependenciesValidatorExceptionHandling:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -75,7 +75,7 @@ class TestCircularDependenciesValidatorExceptionHandling:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -111,7 +111,7 @@ class TestCircularDependenciesValidatorExceptionHandling:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -146,7 +146,7 @@ class TestCircularDependenciesValidatorExceptionHandling:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -203,7 +203,7 @@ class TestCircularDependenciesValidatorExceptionHandling:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -249,7 +249,7 @@ class TestCircularDependenciesValidatorExceptionHandling:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found circular dependency",
@@ -309,7 +309,7 @@ class TestCircularDependenciesValidatorExceptionHandling:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Check for circular dependencies",
             params={"resource_dirs": [".claude/skills", ".claude/commands"]},
             failure_message="Found circular dependency",

--- a/tests/unit/test_claude_mcp_permissions_validator.py
+++ b/tests/unit/test_claude_mcp_permissions_validator.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle
 from drift.validation.validators.client.claude import ClaudeMcpPermissionsValidator
 
@@ -21,7 +21,7 @@ class TestClaudeMcpPermissionsValidator:
     def validation_rule(self):
         """Create validation rule for testing."""
         return ValidationRule(
-            rule_type=ValidationType.CLAUDE_MCP_PERMISSIONS,
+            rule_type="core:claude_mcp_permissions",
             description="Check for MCP permissions",
             failure_message="MCP servers missing permissions",
             expected_behavior="All MCP servers have permissions",

--- a/tests/unit/test_claude_settings_duplicates_validator.py
+++ b/tests/unit/test_claude_settings_duplicates_validator.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle
 from drift.validation.validators.client.claude import ClaudeSettingsDuplicatesValidator
 
@@ -21,7 +21,7 @@ class TestClaudeSettingsDuplicatesValidator:
     def validation_rule(self):
         """Create validation rule for testing."""
         return ValidationRule(
-            rule_type=ValidationType.CLAUDE_SETTINGS_DUPLICATES,
+            rule_type="core:claude_settings_duplicates",
             description="Check for duplicate permissions",
             failure_message="Duplicate permissions found",
             expected_behavior="No duplicate permissions",

--- a/tests/unit/test_dependency_duplicate_failure_details.py
+++ b/tests/unit/test_dependency_duplicate_failure_details.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeDependencyDuplicateValidator
 
@@ -19,7 +19,7 @@ class TestDependencyDuplicateValidatorFailureDetails:
     def validation_rule(self):
         """Create standard validation rule."""
         return ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found redundant dependency",
@@ -520,7 +520,7 @@ class TestDependencyDuplicateValidatorFailureDetails:
         bundles.append(cmd_bundle)
 
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/skills", ".claude/commands"]},
             failure_message="Found redundant dependency",

--- a/tests/unit/test_dependency_duplicate_validator.py
+++ b/tests/unit/test_dependency_duplicate_validator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeDependencyDuplicateValidator
 
@@ -137,7 +137,7 @@ class TestDependencyDuplicateValidator:
         """Test detection of redundant transitive skill dependency."""
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found redundant skill dependencies",
@@ -155,7 +155,7 @@ class TestDependencyDuplicateValidator:
         """Test detection of redundant transitive dependency in command."""
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/commands", ".claude/skills"]},
             failure_message="Found redundant dependencies",
@@ -188,7 +188,7 @@ class TestDependencyDuplicateValidator:
 
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found redundant dependencies",
@@ -202,7 +202,7 @@ class TestDependencyDuplicateValidator:
         """Test validator returns None when all_bundles not provided."""
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found redundant dependencies",
@@ -216,7 +216,7 @@ class TestDependencyDuplicateValidator:
         """Test validator raises error when resource_dirs param missing."""
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={},  # Missing resource_dirs
             failure_message="Found redundant dependencies",
@@ -290,7 +290,7 @@ class TestDependencyDuplicateValidator:
 
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Found redundant dependencies",
@@ -308,7 +308,7 @@ class TestDependencyDuplicateValidator:
 
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for redundant dependencies",
             params={"resource_dirs": [".claude/commands", ".claude/skills"]},
             failure_message="Found redundant dependencies",

--- a/tests/unit/test_dependency_validators_edge_cases.py
+++ b/tests/unit/test_dependency_validators_edge_cases.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.utils.claude_dependency_graph import ClaudeDependencyGraph
 from drift.validation.validators.client.claude_dependency import (
@@ -58,7 +58,7 @@ class TestGraphClassValidation:
         validator = CircularDependenciesValidator(loader=None, graph_class=None)
 
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Test rule",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Failed",
@@ -98,7 +98,7 @@ class TestGraphClassValidation:
         validator = DependencyDuplicateValidator(loader=None, graph_class=None)
 
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Test rule",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Failed",
@@ -138,7 +138,7 @@ class TestGraphClassValidation:
         validator = MaxDependencyDepthValidator(loader=None, graph_class=None)
 
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Test rule",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Failed",
@@ -241,13 +241,13 @@ class TestResourceTypeEdgeCases:
 
         for validator in validators:
             if isinstance(validator, ClaudeCircularDependenciesValidator):
-                rule_type = ValidationType.CIRCULAR_DEPENDENCIES
+                rule_type = "core:circular_dependencies"
                 failure_msg = "Circular dependency found"
             elif isinstance(validator, ClaudeDependencyDuplicateValidator):
-                rule_type = ValidationType.DEPENDENCY_DUPLICATE
+                rule_type = "core:dependency_duplicate"
                 failure_msg = "Redundant dependency found"
             else:
-                rule_type = ValidationType.MAX_DEPENDENCY_DEPTH
+                rule_type = "core:max_dependency_depth"
                 failure_msg = "Max depth exceeded"
 
             rule = ValidationRule(
@@ -306,7 +306,7 @@ class TestExceptionHandlingDuringResourceLoading:
 
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Test rule",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Redundant dependency",
@@ -350,7 +350,7 @@ class TestExceptionHandlingDuringResourceLoading:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Test rule",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Circular dependency",
@@ -394,7 +394,7 @@ class TestExceptionHandlingDuringResourceLoading:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Test rule",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Max depth exceeded",
@@ -453,7 +453,7 @@ class TestKeyErrorHandlingInDuplicateDetection:
 
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Test rule",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Redundant dependency",
@@ -749,7 +749,7 @@ class TestEndToEndIntegration:
 
         validator = ClaudeCircularDependenciesValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.CIRCULAR_DEPENDENCIES,
+            rule_type="core:circular_dependencies",
             description="Detect cycles",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Circular dependency found",
@@ -815,7 +815,7 @@ class TestEndToEndIntegration:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Max depth exceeded",
@@ -875,7 +875,7 @@ class TestEndToEndIntegration:
 
         validator = ClaudeDependencyDuplicateValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check redundancy",
             params={"resource_dirs": [".claude/skills"]},
             failure_message="Redundant dependency",
@@ -941,10 +941,16 @@ class TestMultipleFilesInBundle:
         validators = [
             (
                 ClaudeCircularDependenciesValidator(),
-                ValidationType.CIRCULAR_DEPENDENCIES,
+                "core:claude_circular_dependencies",
             ),
-            (ClaudeDependencyDuplicateValidator(), ValidationType.DEPENDENCY_DUPLICATE),
-            (ClaudeMaxDependencyDepthValidator(), ValidationType.MAX_DEPENDENCY_DEPTH),
+            (
+                ClaudeDependencyDuplicateValidator(),
+                "core:claude_dependency_duplicate",
+            ),
+            (
+                ClaudeMaxDependencyDepthValidator(),
+                "core:claude_max_dependency_depth",
+            ),
         ]
 
         for validator, rule_type in validators:

--- a/tests/unit/test_execution_details_document_validation.py
+++ b/tests/unit/test_execution_details_document_validation.py
@@ -42,7 +42,7 @@ class TestDocumentValidationExecutionDetails:
                             ),
                             rules=[
                                 ValidationRule(
-                                    rule_type="file_exists",
+                                    rule_type="core:file_exists",
                                     description="Validates .claude.md files exist",
                                     file_path=".claude.md",
                                     failure_message=".claude.md file is missing",
@@ -102,7 +102,7 @@ class TestDocumentValidationExecutionDetails:
             validation = claude_md_detail["validation_results"]
 
             assert "rule_type" in validation
-            assert validation["rule_type"] == "file_exists"
+            assert validation["rule_type"] == "core:file_exists"
 
     def test_execution_details_populated_when_no_conversations(self):
         """Test execution_details are populated even when there are 0 conversations."""
@@ -127,7 +127,7 @@ class TestDocumentValidationExecutionDetails:
                             ),
                             rules=[
                                 ValidationRule(
-                                    rule_type="file_exists",
+                                    rule_type="core:file_exists",
                                     description="Test validation",
                                     file_path=".claude.md",
                                     failure_message="Test failure",

--- a/tests/unit/test_file_size_validator.py
+++ b/tests/unit/test_file_size_validator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators.core.file_validators import FileSizeValidator
 
@@ -63,7 +63,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check CLAUDE.md line count",
             file_path="CLAUDE.md",
             max_count=300,
@@ -96,7 +96,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check CLAUDE.md line count",
             file_path="CLAUDE.md",
             max_count=300,
@@ -132,7 +132,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check line count",
             file_path="test.md",
             max_count=300,
@@ -165,7 +165,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check minimum line count",
             file_path="test.md",
             min_count=10,
@@ -200,7 +200,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check byte size",
             file_path="test.txt",
             max_size=1000,
@@ -235,7 +235,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check byte size",
             file_path="test.txt",
             max_size=1000,
@@ -249,7 +249,7 @@ class TestFileSizeValidator:
     def test_file_not_found(self, validator, bundle_with_file):
         """Test validation when file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check nonexistent file",
             file_path="nonexistent.md",
             max_count=100,
@@ -265,7 +265,7 @@ class TestFileSizeValidator:
     def test_missing_file_path(self, validator, bundle_with_file):
         """Test that validator raises error when file_path is missing."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="No file path",
             max_count=100,
             failure_message="Error",
@@ -278,7 +278,7 @@ class TestFileSizeValidator:
     def test_no_constraints(self, validator, bundle_with_file):
         """Test that validation passes when no constraints are specified."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="No constraints",
             file_path="test.md",
             failure_message="Error",
@@ -310,7 +310,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check both constraints",
             file_path="test.md",
             max_count=100,
@@ -347,7 +347,7 @@ class TestFileSizeValidator:
 
         # Empty file should pass max constraints
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check empty file",
             file_path="empty.md",
             max_count=100,
@@ -379,7 +379,7 @@ class TestFileSizeValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_SIZE,
+            rule_type="core:file_size",
             description="Check single line",
             file_path="single.md",
             max_count=10,

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -75,6 +75,7 @@ class TestMarkdownFormatter:
                 total_rule_violations=1,
                 conversations_with_drift=1,
                 by_type={"incomplete_work": 1},
+                by_group={"General": 1},
                 by_agent={"claude-code": 1},
                 rules_checked=["incomplete_work"],
             ),
@@ -90,6 +91,7 @@ class TestMarkdownFormatter:
         # Check summary
         assert "Total conversations: 1" in output
         assert "Total rules: 1" in output
+        assert "General (1)" in output
         assert "incomplete_work (1)" in output
         assert "claude-code (1)" in output
 
@@ -719,6 +721,7 @@ class TestJsonFormatter:
                 total_rule_violations=1,
                 conversations_with_drift=1,
                 by_type={"incomplete_work": 1},
+                by_group={"General": 1},
                 by_agent={"claude-code": 1},
             ),
             results=[analysis_result],
@@ -732,6 +735,7 @@ class TestJsonFormatter:
         # Check summary
         assert data["summary"]["conversations_analyzed"] == 1
         assert data["summary"]["conversations_with_drift"] == 1
+        assert data["summary"]["by_group"]["General"] == 1
         assert data["summary"]["by_type"]["incomplete_work"] == 1
         assert data["summary"]["by_agent"]["claude-code"] == 1
 

--- a/tests/unit/test_json_schema_validator.py
+++ b/tests/unit/test_json_schema_validator.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators.core.format_validators import JsonSchemaValidator
 
@@ -66,7 +66,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate data.json",
             file_path="data.json",
             params={"schema": schema},
@@ -97,7 +97,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate data.json",
             file_path="data.json",
             params={"schema": schema},
@@ -129,7 +129,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate data.json",
             file_path="data.json",
             params={"schema": schema},
@@ -167,7 +167,7 @@ class TestJsonSchemaValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate data.json",
             file_path="data.json",
             params={"schema_file": "schema.json"},
@@ -181,7 +181,7 @@ class TestJsonSchemaValidator:
     def test_external_schema_file_not_found(self, validator, bundle_with_json):
         """Test that validation fails gracefully when schema file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate config.json",
             file_path="config.json",
             params={"schema_file": "nonexistent_schema.json"},
@@ -210,7 +210,7 @@ class TestJsonSchemaValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate data.json",
             file_path="data.json",
             params={"schema_file": "bad_schema.json"},
@@ -227,7 +227,7 @@ class TestJsonSchemaValidator:
     def test_missing_file_path(self, validator, bundle_with_json):
         """Test that validator raises error when file_path is missing."""
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="No file path",
             params={"schema": {"type": "object"}},
             failure_message="Error",
@@ -240,7 +240,7 @@ class TestJsonSchemaValidator:
     def test_missing_params(self, validator, bundle_with_json):
         """Test that validator raises error when params is missing."""
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="No params",
             file_path="config.json",
             failure_message="Error",
@@ -253,7 +253,7 @@ class TestJsonSchemaValidator:
     def test_missing_schema_and_schema_file(self, validator, bundle_with_json):
         """Test that validation fails when neither schema nor schema_file provided."""
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="No schema",
             file_path="config.json",
             params={"other_param": "value"},
@@ -268,7 +268,7 @@ class TestJsonSchemaValidator:
     def test_file_not_found(self, validator, bundle_with_json):
         """Test validation when JSON file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Check nonexistent file",
             file_path="nonexistent.json",
             params={"schema": {"type": "object"}},
@@ -294,7 +294,7 @@ class TestJsonSchemaValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate bad JSON",
             file_path="bad.json",
             params={"schema": {"type": "object"}},
@@ -320,7 +320,7 @@ class TestJsonSchemaValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate JSON",
             file_path="data.json",
             params={"schema": {"type": "object"}},
@@ -375,7 +375,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate nested structure",
             file_path="nested.json",
             params={"schema": schema},
@@ -415,7 +415,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate array",
             file_path="array.json",
             params={"schema": schema},
@@ -445,7 +445,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate enum",
             file_path="enum.json",
             params={"schema": schema},
@@ -475,7 +475,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate enum",
             file_path="enum.json",
             params={"schema": schema},
@@ -506,7 +506,7 @@ class TestJsonSchemaValidator:
         schema = {"type": "object", "properties": {}}
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate empty object",
             file_path="empty.json",
             params={"schema": schema},
@@ -536,7 +536,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate with extra properties",
             file_path="data.json",
             params={"schema": schema},
@@ -567,7 +567,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Validate strict schema",
             file_path="data.json",
             params={"schema": schema},
@@ -606,7 +606,7 @@ class TestJsonSchemaValidator:
         schema = {"type": "object", "properties": {"name": {"type": "string"}}}
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Test rule",
             file_path="data.json",
             params={"schema": schema},
@@ -638,7 +638,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Test rule",
             file_path="data.json",
             params={"schema": schema},
@@ -678,7 +678,7 @@ class TestJsonSchemaValidator:
         monkeypatch.setattr(builtins, "open", mock_open)
 
         _ = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Test rule",
             file_path="data.json",
             params={"schema_file": "schema.json"},
@@ -706,7 +706,7 @@ class TestJsonSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.JSON_SCHEMA,
+            rule_type="core:json_schema",
             description="Test rule",
             file_path="data.json",
             params={"schema": schema},

--- a/tests/unit/test_markdown_link_validator.py
+++ b/tests/unit/test_markdown_link_validator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators.core.markdown_validators import MarkdownLinkValidator
 
@@ -50,7 +50,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check markdown links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -87,7 +87,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check markdown links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -126,7 +126,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check external links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -166,7 +166,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -206,7 +206,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -247,7 +247,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -293,7 +293,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -337,7 +337,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check links",
             failure_message="Broken links found",
             expected_behavior="All links should be valid",
@@ -386,7 +386,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check resource references",
             failure_message="Broken resource references found",
             expected_behavior="All resource references should be valid",
@@ -426,7 +426,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check resource references",
             failure_message="Broken resource references found",
             expected_behavior="All resource references should be valid",
@@ -472,7 +472,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check resource references",
             failure_message="Broken resource references found",
             expected_behavior="All resource references should be valid",
@@ -517,7 +517,7 @@ class TestMarkdownLinkValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check resource references",
             failure_message="Broken resource references found",
             expected_behavior="All resource references should be valid",

--- a/tests/unit/test_max_dependency_depth_failure_details.py
+++ b/tests/unit/test_max_dependency_depth_failure_details.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeMaxDependencyDepthValidator
 
@@ -19,7 +19,7 @@ class TestMaxDependencyDepthValidatorFailureDetails:
     def validation_rule(self):
         """Create standard validation rule with max_depth=3."""
         return ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain exceeds maximum depth",
@@ -325,7 +325,7 @@ class TestMaxDependencyDepthValidatorFailureDetails:
 
         # Use max_depth of 2 to trigger violation
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Dependency chain exceeds maximum depth",
@@ -502,7 +502,7 @@ class TestMaxDependencyDepthValidatorFailureDetails:
             )
 
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain exceeds maximum depth",

--- a/tests/unit/test_max_dependency_depth_validator.py
+++ b/tests/unit/test_max_dependency_depth_validator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeMaxDependencyDepthValidator
 
@@ -82,7 +82,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -118,7 +118,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 5},
             failure_message="Dependency chain too deep",
@@ -151,7 +151,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -199,7 +199,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Dependency chain too deep",
@@ -229,7 +229,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"]},  # No max_depth specified
             failure_message="Dependency chain too deep",
@@ -281,7 +281,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Dependency chain too deep",
@@ -312,7 +312,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -341,7 +341,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"max_depth": 3},  # Missing resource_dirs
             failure_message="Dependency chain too deep",
@@ -374,7 +374,7 @@ class TestMaxDependencyDepthValidator:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",

--- a/tests/unit/test_max_dependency_depth_validator_additional.py
+++ b/tests/unit/test_max_dependency_depth_validator_additional.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeMaxDependencyDepthValidator
 
@@ -40,7 +40,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -75,7 +75,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -112,7 +112,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -147,7 +147,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -204,7 +204,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 3},
             failure_message="Dependency chain too deep",
@@ -280,7 +280,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 2},
             failure_message="Dependency chain too deep",
@@ -346,7 +346,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/agents", ".claude/skills"], "max_depth": 2},
             failure_message="Dependency chain too deep",
@@ -402,7 +402,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 0},
             failure_message="Dependency chain too deep",
@@ -458,7 +458,7 @@ class TestMaxDependencyDepthValidatorExceptionHandling:
 
         validator = ClaudeMaxDependencyDepthValidator()
         rule = ValidationRule(
-            rule_type=ValidationType.MAX_DEPENDENCY_DEPTH,
+            rule_type="core:max_dependency_depth",
             description="Check dependency depth",
             params={"resource_dirs": [".claude/skills"], "max_depth": 1000},
             failure_message="Dependency chain too deep",

--- a/tests/unit/test_new_validators.py
+++ b/tests/unit/test_new_validators.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle
 from drift.documents.loader import DocumentLoader
 from drift.validation.validators import (
@@ -55,7 +55,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH with all_in mode passes when all items found."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Check skills match",
             params={
                 "items": {"type": "string_list", "value": ["skill-one", "skill-two"]},
@@ -73,7 +73,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH with all_in mode fails when items missing."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Check skills match",
             params={
                 "items": {"type": "string_list", "value": ["skill-one", "skill-missing"]},
@@ -92,7 +92,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH with none_in mode passes when no items found."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Check no forbidden skills",
             params={
                 "items": {"type": "string_list", "value": ["forbidden-skill"]},
@@ -110,7 +110,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH with none_in mode fails when items found."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Check no forbidden skills",
             params={
                 "items": {"type": "string_list", "value": ["skill-one"]},
@@ -129,7 +129,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH with exact mode passes when lists match."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Check exact skill match",
             params={
                 "items": {"type": "string_list", "value": ["skill-one", "skill-two"]},
@@ -147,7 +147,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH with exact mode fails when lists differ."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Check exact skill match",
             params={
                 "items": {"type": "string_list", "value": ["skill-one"]},
@@ -165,7 +165,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH uses all_in as default mode."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Check skills",
             params={
                 "items": {"type": "string_list", "value": ["skill-one"]},
@@ -182,7 +182,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH raises error when params missing."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Invalid rule",
             params={},
             failure_message="Error",
@@ -196,7 +196,7 @@ class TestListMatchValidator:
         """Test LIST_MATCH raises error with unknown match_mode."""
         validator = ListMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Invalid mode",
             params={
                 "items": {"type": "string_list", "value": ["skill-one"]},
@@ -253,7 +253,7 @@ class TestListRegexMatchValidator:
         """Test LIST_REGEX_MATCH with all_in mode passes when all found."""
         validator = ListRegexMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_REGEX_MATCH,
+            rule_type="core:list_regex_match",
             description="Check skills authorized",
             params={
                 "items": {"type": "resource_list", "value": "skill"},
@@ -277,7 +277,7 @@ class TestListRegexMatchValidator:
 
         validator = ListRegexMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_REGEX_MATCH,
+            rule_type="core:list_regex_match",
             description="Check skills authorized",
             params={
                 "items": {"type": "resource_list", "value": "skill"},
@@ -297,7 +297,7 @@ class TestListRegexMatchValidator:
         """Test LIST_REGEX_MATCH with none_in mode passes when not found."""
         validator = ListRegexMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_REGEX_MATCH,
+            rule_type="core:list_regex_match",
             description="Check no forbidden skills",
             params={
                 "items": {"type": "string_list", "value": ["forbidden-skill"]},
@@ -316,7 +316,7 @@ class TestListRegexMatchValidator:
         """Test LIST_REGEX_MATCH with none_in mode fails when found."""
         validator = ListRegexMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_REGEX_MATCH,
+            rule_type="core:list_regex_match",
             description="Check no forbidden skills",
             params={
                 "items": {"type": "string_list", "value": ["api-skill"]},
@@ -336,7 +336,7 @@ class TestListRegexMatchValidator:
         """Test LIST_REGEX_MATCH raises error when params missing."""
         validator = ListRegexMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_REGEX_MATCH,
+            rule_type="core:list_regex_match",
             description="Invalid rule",
             params={},
             failure_message="Error",
@@ -350,7 +350,7 @@ class TestListRegexMatchValidator:
         """Test LIST_REGEX_MATCH raises error with unknown match_mode."""
         validator = ListRegexMatchValidator(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_REGEX_MATCH,
+            rule_type="core:list_regex_match",
             description="Invalid mode",
             params={
                 "items": {"type": "string_list", "value": ["api-skill"]},
@@ -396,18 +396,18 @@ class TestValidatorRegistryWithNewValidators:
     def test_registry_includes_list_match(self, loader):
         """Test registry includes LIST_MATCH validator."""
         registry = ValidatorRegistry(loader)
-        assert ValidationType.LIST_MATCH in registry._validators
+        assert "core:list_match" in registry._validators
 
     def test_registry_includes_list_regex_match(self, loader):
         """Test registry includes LIST_REGEX_MATCH validator."""
         registry = ValidatorRegistry(loader)
-        assert ValidationType.LIST_REGEX_MATCH in registry._validators
+        assert "core:list_regex_match" in registry._validators
 
     def test_registry_execute_list_match_rule(self, bundle, loader):
         """Test registry can execute LIST_MATCH rules."""
         registry = ValidatorRegistry(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_MATCH,
+            rule_type="core:list_match",
             description="Test",
             params={
                 "items": {"type": "string_list", "value": ["test-skill"]},
@@ -427,7 +427,7 @@ class TestValidatorRegistryWithNewValidators:
 
         registry = ValidatorRegistry(loader)
         rule = ValidationRule(
-            rule_type=ValidationType.LIST_REGEX_MATCH,
+            rule_type="core:list_regex_match",
             description="Test",
             params={
                 "items": {"type": "string_list", "value": ["test-skill"]},

--- a/tests/unit/test_parallel_execution.py
+++ b/tests/unit/test_parallel_execution.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from drift.config.models import DriftConfig, ParallelExecutionConfig, ValidationRule, ValidationType
+from drift.config.models import DriftConfig, ParallelExecutionConfig, ValidationRule
 from drift.core.analyzer import DriftAnalyzer
 from drift.core.types import DocumentBundle, DocumentFile, DocumentRule
 
@@ -50,21 +50,21 @@ def sample_validation_rules():
     """Create sample validation rules for testing."""
     return [
         ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test rule 1",
             file_path="test1.txt",
             failure_message="File test1.txt should exist",
             expected_behavior="File should exist",
         ),
         ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test rule 2",
             file_path="test2.txt",
             failure_message="File test2.txt should exist",
             expected_behavior="File should exist",
         ),
         ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test rule 3",
             file_path="test3.txt",
             failure_message="File test3.txt should exist",
@@ -136,7 +136,7 @@ class TestExecutionRouting:
         analyzer = DriftAnalyzer(config=mock_config, project_path=temp_project)
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Single test rule",
             file_path="test.txt",
             failure_message="File should exist",
@@ -172,7 +172,7 @@ class TestExecutionRouting:
 
         rules = [
             ValidationRule(
-                rule_type=ValidationType.FILE_EXISTS,
+                rule_type="core:file_exists",
                 description=f"Test rule {i}",
                 file_path=f"test{i}.txt",
                 failure_message=f"File test{i}.txt should exist",
@@ -219,7 +219,7 @@ class TestExecutionRouting:
 
         rules = [
             ValidationRule(
-                rule_type=ValidationType.FILE_EXISTS,
+                rule_type="core:file_exists",
                 description=f"Test rule {i}",
                 file_path=f"test{i}.txt",
                 failure_message=f"File test{i}.txt should exist",
@@ -443,7 +443,7 @@ class TestAsyncHelpers:
         analyzer = DriftAnalyzer(config=mock_config, project_path=temp_project)
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test rule",
             file_path="test.txt",
             failure_message="File should exist",
@@ -475,7 +475,7 @@ class TestAsyncHelpers:
         analyzer = DriftAnalyzer(config=mock_config, project_path=temp_project)
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test rule",
             file_path="test.txt",
             failure_message="File should exist",
@@ -505,7 +505,7 @@ class TestAsyncHelpers:
         analyzer = DriftAnalyzer(config=mock_config, project_path=temp_project)
 
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test rule",
             file_path="test.txt",
             failure_message="File should exist",

--- a/tests/unit/test_plugin_namespace_validation.py
+++ b/tests/unit/test_plugin_namespace_validation.py
@@ -1,0 +1,412 @@
+"""Unit tests for namespace validation and PhaseDefinition provider validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from drift.config.models import VALIDATION_TYPE_PATTERN, PhaseDefinition
+
+
+class TestNamespacePatternValidation:
+    """Tests for VALIDATION_TYPE_PATTERN regex validation."""
+
+    def test_valid_namespace_formats(self):
+        """Test that valid namespace formats match the pattern."""
+        valid_formats = [
+            "core:file_exists",
+            "security:scan",
+            "my_company:check",
+            "custom:validator",
+            "a:b",  # Minimal valid format
+            "my_namespace:my_type_123",
+            "namespace123:type456",
+            "long_namespace_name:long_type_name",
+        ]
+
+        for format_str in valid_formats:
+            assert VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Valid format '{format_str}' should match pattern"
+
+    def test_invalid_namespace_no_colon(self):
+        """Test that formats without colon are rejected."""
+        invalid_formats = [
+            "no_namespace",
+            "justtext",
+            "file_exists",
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Invalid format '{format_str}' should not match pattern"
+
+    def test_invalid_namespace_uppercase(self):
+        """Test that uppercase letters are rejected."""
+        invalid_formats = [
+            "Core:test",
+            "core:Test",
+            "CORE:test",
+            "MyNamespace:test",
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Invalid format '{format_str}' should not match pattern (uppercase)"
+
+    def test_invalid_namespace_empty_parts(self):
+        """Test that empty namespace or type parts are rejected."""
+        invalid_formats = [
+            ":test",  # Empty namespace
+            "test:",  # Empty type
+            ":",  # Both empty
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Invalid format '{format_str}' should not match pattern (empty parts)"
+
+    def test_invalid_namespace_dashes(self):
+        """Test that dashes are rejected (only underscores allowed)."""
+        invalid_formats = [
+            "test-dash:scan",
+            "core:test-type",
+            "my-namespace:my-type",
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Invalid format '{format_str}' should not match pattern (dashes)"
+
+    def test_invalid_namespace_special_chars(self):
+        """Test that special characters are rejected."""
+        invalid_formats = [
+            "core@test:scan",
+            "core:test!",
+            "core.test:scan",
+            "core:test.scan",
+            "core/test:scan",
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Invalid format '{format_str}' should not match pattern (special chars)"
+
+    def test_invalid_namespace_starts_with_digit(self):
+        """Test that namespaces/types starting with digits are rejected."""
+        invalid_formats = [
+            "123namespace:test",
+            "namespace:123test",
+            "1:2",
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Invalid format '{format_str}' should not match pattern (starts with digit)"
+
+    def test_valid_namespace_contains_digits(self):
+        """Test that digits in the middle/end are allowed."""
+        valid_formats = [
+            "namespace123:test",
+            "test:type456",
+            "ns1:type2",
+        ]
+
+        for format_str in valid_formats:
+            assert VALIDATION_TYPE_PATTERN.match(
+                format_str
+            ), f"Valid format '{format_str}' should match pattern (contains digits)"
+
+
+class TestPhaseDefinitionProviderValidation:
+    """Tests for PhaseDefinition provider field validation."""
+
+    def test_prompt_type_no_provider_validation(self):
+        """Test that prompt type doesn't validate provider field."""
+        # Should work with provider
+        phase = PhaseDefinition(
+            name="test",
+            type="prompt",
+            prompt="Test prompt",
+            provider="some.module:Class",  # Should be ignored
+        )
+        assert phase.type == "prompt"
+        assert phase.provider == "some.module:Class"
+
+        # Should work without provider
+        phase2 = PhaseDefinition(
+            name="test",
+            type="prompt",
+            prompt="Test prompt",
+        )
+        assert phase2.type == "prompt"
+        assert phase2.provider is None
+
+    def test_core_type_must_not_have_provider(self):
+        """Test that core:* types must NOT have a provider."""
+        with pytest.raises(ValidationError) as exc_info:
+            PhaseDefinition(
+                name="test",
+                type="core:file_exists",
+                provider="some.module:Class",  # Should error
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Core validation type 'core:file_exists' must not have a provider" in error_msg
+        assert "Set provider to None or omit it" in error_msg
+
+    def test_core_type_without_provider_succeeds(self):
+        """Test that core:* types work without provider."""
+        phase = PhaseDefinition(
+            name="test",
+            type="core:file_exists",
+            file_path="test.txt",
+        )
+        assert phase.type == "core:file_exists"
+        assert phase.provider is None
+
+        # Explicitly setting to None should also work
+        phase2 = PhaseDefinition(
+            name="test",
+            type="core:file_exists",
+            provider=None,
+            file_path="test.txt",
+        )
+        assert phase2.provider is None
+
+    def test_custom_type_must_have_provider(self):
+        """Test that non-core types MUST have a provider."""
+        with pytest.raises(ValidationError) as exc_info:
+            PhaseDefinition(
+                name="test",
+                type="security:scan",  # Non-core type
+                provider=None,  # Explicitly None (missing provider)
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Custom validation type 'security:scan' requires a provider" in error_msg
+        assert "Specify provider as 'module.path:ClassName'" in error_msg
+
+    def test_custom_type_with_provider_succeeds(self):
+        """Test that non-core types work with provider."""
+        phase = PhaseDefinition(
+            name="test",
+            type="security:scan",
+            provider="mypackage.validators:SecurityValidator",
+        )
+        assert phase.type == "security:scan"
+        assert phase.provider == "mypackage.validators:SecurityValidator"
+
+    def test_provider_format_validation(self):
+        """Test that provider format must be 'module.path:ClassName'."""
+        # Valid formats
+        valid_providers = [
+            "module:Class",
+            "package.module:Class",
+            "package.subpackage.module:ClassName",
+            "a.b.c:D",
+        ]
+
+        for provider in valid_providers:
+            phase = PhaseDefinition(
+                name="test",
+                type="custom:type",
+                provider=provider,
+            )
+            assert phase.provider == provider
+
+    def test_provider_format_invalid_no_colon(self):
+        """Test that provider without colon is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            PhaseDefinition(
+                name="test",
+                type="custom:type",
+                provider="module.Class",  # Missing colon
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Invalid provider format: 'module.Class'" in error_msg
+        assert "Must be 'module.path:ClassName'" in error_msg
+
+    def test_provider_format_invalid_empty_module(self):
+        """Test that provider with empty module part is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            PhaseDefinition(
+                name="test",
+                type="custom:type",
+                provider=":ClassName",  # Empty module
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Invalid provider format" in error_msg
+
+    def test_provider_format_invalid_empty_class(self):
+        """Test that provider with empty class part is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            PhaseDefinition(
+                name="test",
+                type="custom:type",
+                provider="module.path:",  # Empty class
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Invalid provider format" in error_msg
+
+    def test_validation_type_format_validated(self):
+        """Test that validation type format is validated for namespaced types."""
+        # Type without colon (non-namespaced) doesn't trigger provider validation
+        # Only types with colons are validated
+        # So we test an invalid namespaced type
+        with pytest.raises(ValidationError) as exc_info:
+            PhaseDefinition(
+                name="test",
+                type="Invalid-Format:test",  # Invalid namespace (dash not allowed)
+                provider="module:Class",
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Invalid validation type format: 'Invalid-Format:test'" in error_msg
+        assert "Must match pattern: namespace:type" in error_msg
+
+    def test_validation_type_format_uppercase_rejected(self):
+        """Test that uppercase in validation type is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            PhaseDefinition(
+                name="test",
+                type="Core:test",  # Uppercase C
+                provider="module:Class",
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Invalid validation type format: 'Core:test'" in error_msg
+
+    def test_multiple_core_validators(self):
+        """Test that all core validators work without provider."""
+        core_types = [
+            "core:file_exists",
+            "core:file_size",
+            "core:token_count",
+            "core:regex_match",
+            "core:json_schema",
+        ]
+
+        for core_type in core_types:
+            phase = PhaseDefinition(
+                name="test",
+                type=core_type,
+            )
+            assert phase.type == core_type
+            assert phase.provider is None
+
+    def test_multiple_custom_validators_with_providers(self):
+        """Test that multiple custom validators work with different providers."""
+        custom_configs = [
+            ("security:scan", "security_pkg:ScanValidator"),
+            ("quality:check", "quality_pkg:CheckValidator"),
+            ("compliance:audit", "compliance_pkg.validators:AuditValidator"),
+        ]
+
+        for val_type, provider in custom_configs:
+            phase = PhaseDefinition(
+                name="test",
+                type=val_type,
+                provider=provider,
+            )
+            assert phase.type == val_type
+            assert phase.provider == provider
+
+    def test_core_type_empty_string_provider_succeeds(self):
+        """Test that core types with empty string provider are treated as no provider."""
+        # Empty string is falsy in Python, so `if v:` evaluates to False
+        # This means empty string is treated as "no provider" and should succeed
+        phase = PhaseDefinition(
+            name="test",
+            type="core:file_exists",
+            provider="",  # Empty string is falsy, treated as no provider
+        )
+
+        assert phase.provider == ""  # Empty string is preserved
+        # This is acceptable since the validation checks `if v:` which is False for empty string
+
+    def test_phase_definition_with_all_fields(self):
+        """Test PhaseDefinition with all optional fields."""
+        phase = PhaseDefinition(
+            name="custom_validation",
+            type="security:scan",
+            provider="security_pkg:ScanValidator",
+            params={"severity": "high", "scan_depth": 3},
+            file_path="config.yaml",
+            failure_message="Security issue found",
+            expected_behavior="No security issues",
+        )
+
+        assert phase.name == "custom_validation"
+        assert phase.type == "security:scan"
+        assert phase.provider == "security_pkg:ScanValidator"
+        assert phase.params == {"severity": "high", "scan_depth": 3}
+        assert phase.file_path == "config.yaml"
+        assert phase.failure_message == "Security issue found"
+        assert phase.expected_behavior == "No security issues"
+
+
+class TestEdgeCases:
+    """Tests for edge cases in namespace and provider validation."""
+
+    def test_type_with_multiple_colons(self):
+        """Test that types with multiple colons are rejected."""
+        # The pattern only allows one colon
+        assert not VALIDATION_TYPE_PATTERN.match("namespace:type:extra")
+
+    def test_very_long_namespace_and_type(self):
+        """Test that very long but valid names work."""
+        long_namespace = "very_long_namespace_name_with_many_words"
+        long_type = "very_long_type_name_with_many_words_123"
+        valid_format = f"{long_namespace}:{long_type}"
+
+        assert VALIDATION_TYPE_PATTERN.match(valid_format)
+
+        phase = PhaseDefinition(
+            name="test",
+            type=valid_format,
+            provider="module:Class",
+        )
+        assert phase.type == valid_format
+
+    def test_whitespace_in_validation_type(self):
+        """Test that whitespace in validation type is rejected."""
+        invalid_formats = [
+            "core :file_exists",
+            "core: file_exists",
+            "core:file_exists ",
+            " core:file_exists",
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(format_str)
+
+    def test_unicode_in_validation_type(self):
+        """Test that unicode characters are rejected."""
+        invalid_formats = [
+            "core:file_exists_\u00e9",  # e with accent
+            "\u4e2d\u6587:test",  # Chinese characters
+            "core:test_\u0444",  # Cyrillic character
+        ]
+
+        for format_str in invalid_formats:
+            assert not VALIDATION_TYPE_PATTERN.match(format_str)
+
+    def test_provider_with_multiple_colons(self):
+        """Test that provider with multiple colons works (namespaced module)."""
+        # This should actually fail based on the validation logic
+        # which splits on the last colon
+        phase = PhaseDefinition(
+            name="test",
+            type="custom:type",
+            provider="package:subpackage:Class",  # Multiple colons
+        )
+        # This will pass because rsplit(":", 1) will split on the last colon
+        assert phase.provider == "package:subpackage:Class"

--- a/tests/unit/test_plugin_registry.py
+++ b/tests/unit/test_plugin_registry.py
@@ -1,0 +1,535 @@
+"""Unit tests for ValidatorRegistry plugin loading system."""
+
+from typing import List, Literal, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentRule
+from drift.validation.validators import BaseValidator, ValidatorRegistry
+
+
+class MockPluginValidator(BaseValidator):
+    """Mock validator for testing plugin loading."""
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "security:scan"
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type for this validator."""
+        return "programmatic"
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Mock validation - always passes."""
+        return None
+
+
+class MockPluginValidatorWrongType(BaseValidator):
+    """Mock validator with mismatched validation type."""
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "security:different"  # Different from what's requested
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type for this validator."""
+        return "programmatic"
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Mock validation - always passes."""
+        return None
+
+
+class NotAValidator:
+    """Class that doesn't inherit from BaseValidator."""
+
+    pass
+
+
+class TestPluginLoading:
+    """Tests for ValidatorRegistry._load_validator() method."""
+
+    def test_load_valid_plugin_class(self):
+        """Test successfully loading a valid plugin class."""
+        registry = ValidatorRegistry()
+
+        # Mock the import_module to return our test module
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockPluginValidator = MockPluginValidator
+            mock_import.return_value = mock_module
+
+            # Load the validator
+            validator = registry._load_validator(
+                provider="test.module:MockPluginValidator",
+                validation_type="security:scan",
+            )
+
+            assert isinstance(validator, MockPluginValidator)
+            assert validator.validation_type == "security:scan"
+            # Should be registered in the registry
+            assert "security:scan" in registry._validators
+
+    def test_load_plugin_module_not_found(self):
+        """Test error when module not found."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_import.side_effect = ModuleNotFoundError("No module named 'nonexistent'")
+
+            with pytest.raises(ModuleNotFoundError) as exc_info:
+                registry._load_validator(
+                    provider="nonexistent.module:SomeValidator",
+                    validation_type="custom:validator",
+                )
+
+            assert "Provider module not found: nonexistent.module" in str(exc_info.value)
+            assert "Is the package installed?" in str(exc_info.value)
+
+    def test_load_plugin_class_not_found(self):
+        """Test error when class not found in module."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            # Create a real empty module-like object that doesn't have the class
+            import types
+
+            mock_module = types.ModuleType("test_module")
+            mock_import.return_value = mock_module
+
+            with pytest.raises(AttributeError) as exc_info:
+                registry._load_validator(
+                    provider="test.module:MissingClass",
+                    validation_type="custom:validator",
+                )
+
+            assert "Provider class not found: MissingClass in test.module" in str(exc_info.value)
+
+    def test_load_plugin_not_basevalidator_subclass(self):
+        """Test error when class doesn't inherit from BaseValidator."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.NotAValidator = NotAValidator
+            mock_import.return_value = mock_module
+
+            with pytest.raises(TypeError) as exc_info:
+                registry._load_validator(
+                    provider="test.module:NotAValidator",
+                    validation_type="custom:validator",
+                )
+
+            assert "Provider class NotAValidator must inherit from BaseValidator" in str(
+                exc_info.value
+            )
+
+    def test_load_plugin_caches_after_first_load(self):
+        """Test that plugins are cached after first load (singleton pattern)."""
+        # Clear the class-level cache before testing
+        ValidatorRegistry._loaded_plugins.clear()
+
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockPluginValidator = MockPluginValidator
+            mock_import.return_value = mock_module
+
+            # First load - cache should be empty
+            cache_key = "security:scan:test.module:MockPluginValidator"
+            assert cache_key not in ValidatorRegistry._loaded_plugins
+
+            # Load validator first time
+            validator1 = registry._load_validator(
+                provider="test.module:MockPluginValidator",
+                validation_type="security:scan",
+            )
+
+            # Should have been added to cache
+            assert cache_key in ValidatorRegistry._loaded_plugins
+            assert mock_import.call_count == 1
+
+            # Second load - should use cache, not import again
+            validator2 = registry._load_validator(
+                provider="test.module:MockPluginValidator",
+                validation_type="security:scan",
+            )
+
+            # Should still only have imported once (using cache for second call)
+            assert mock_import.call_count == 1
+            # Both should be instances of the same class
+            assert isinstance(validator1, type(validator2))
+
+    def test_load_plugin_duplicate_namespace_type(self):
+        """Test error when validation type already registered by another validator."""
+        registry = ValidatorRegistry()
+
+        # core:file_exists is already registered by builtin validator
+        with patch("importlib.import_module") as mock_import:
+            # Create a mock validator that claims to be core:file_exists
+            class DuplicateValidator(BaseValidator):
+                @property
+                def validation_type(self) -> str:
+                    return "core:file_exists"
+
+                @property
+                def computation_type(self) -> Literal["programmatic", "llm"]:
+                    return "programmatic"
+
+                def validate(
+                    self,
+                    rule: ValidationRule,
+                    bundle: DocumentBundle,
+                    all_bundles: Optional[List[DocumentBundle]] = None,
+                ) -> Optional[DocumentRule]:
+                    return None
+
+            mock_module = MagicMock()
+            mock_module.DuplicateValidator = DuplicateValidator
+            mock_import.return_value = mock_module
+
+            with pytest.raises(ValueError) as exc_info:
+                registry._load_validator(
+                    provider="test.module:DuplicateValidator",
+                    validation_type="core:file_exists",
+                )
+
+            assert "Validation type 'core:file_exists' already registered" in str(exc_info.value)
+            assert "FileExistsValidator" in str(exc_info.value)
+
+    def test_load_plugin_type_mismatch(self):
+        """Test error when plugin declares different type than requested."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockPluginValidatorWrongType = MockPluginValidatorWrongType
+            mock_import.return_value = mock_module
+
+            with pytest.raises(ValueError) as exc_info:
+                registry._load_validator(
+                    provider="test.module:MockPluginValidatorWrongType",
+                    validation_type="security:scan",  # Requested type
+                )
+
+            assert "declares validation_type 'security:different'" in str(exc_info.value)
+            assert "but was requested for 'security:scan'" in str(exc_info.value)
+
+    def test_load_plugin_invalid_provider_format(self):
+        """Test error when provider format is invalid."""
+        registry = ValidatorRegistry()
+
+        # Missing colon separator
+        with pytest.raises(ValueError) as exc_info:
+            registry._load_validator(
+                provider="test.module.ClassName",  # No colon
+                validation_type="custom:validator",
+            )
+
+        assert "Invalid provider format" in str(exc_info.value)
+        assert "Must be 'module.path:ClassName'" in str(exc_info.value)
+
+
+class TestGetValidator:
+    """Tests for ValidatorRegistry._get_validator() method."""
+
+    def test_get_builtin_validator(self):
+        """Test getting a built-in core validator."""
+        registry = ValidatorRegistry()
+
+        validator = registry._get_validator("core:file_exists")
+
+        assert validator is not None
+        assert validator.validation_type == "core:file_exists"
+        assert validator.computation_type == "programmatic"
+
+    def test_get_validator_with_provider(self):
+        """Test getting a validator with provider loading."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockPluginValidator = MockPluginValidator
+            mock_import.return_value = mock_module
+
+            validator = registry._get_validator(
+                rule_type="security:scan",
+                provider="test.module:MockPluginValidator",
+            )
+
+            assert validator is not None
+            assert validator.validation_type == "security:scan"
+
+    def test_get_validator_not_found_no_provider(self):
+        """Test error when validator not found and no provider given."""
+        registry = ValidatorRegistry()
+
+        with pytest.raises(ValueError) as exc_info:
+            registry._get_validator("custom:missing")
+
+        assert "Unsupported validation rule type: custom:missing" in str(exc_info.value)
+        assert "For custom validators, specify a provider" in str(exc_info.value)
+
+    def test_get_cached_validator(self):
+        """Test that getting a validator uses cache."""
+        registry = ValidatorRegistry()
+
+        # Get validator twice
+        validator1 = registry._get_validator("core:file_exists")
+        validator2 = registry._get_validator("core:file_exists")
+
+        # Should be the exact same instance
+        assert validator1 is validator2
+
+
+class TestRegistryComputationType:
+    """Tests for get_computation_type and is_programmatic methods."""
+
+    def test_get_computation_type_builtin(self):
+        """Test getting computation type for built-in validator."""
+        registry = ValidatorRegistry()
+
+        assert registry.get_computation_type("core:file_exists") == "programmatic"
+        assert registry.get_computation_type("core:regex_match") == "programmatic"
+
+    def test_get_computation_type_plugin(self):
+        """Test getting computation type for plugin validator."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockPluginValidator = MockPluginValidator
+            mock_import.return_value = mock_module
+
+            comp_type = registry.get_computation_type(
+                "security:scan",
+                provider="test.module:MockPluginValidator",
+            )
+
+            assert comp_type == "programmatic"
+
+    def test_is_programmatic_builtin(self):
+        """Test is_programmatic for built-in validators."""
+        registry = ValidatorRegistry()
+
+        assert registry.is_programmatic("core:file_exists") is True
+        assert registry.is_programmatic("core:file_size") is True
+
+    def test_is_programmatic_plugin(self):
+        """Test is_programmatic for plugin validators."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockPluginValidator = MockPluginValidator
+            mock_import.return_value = mock_module
+
+            is_prog = registry.is_programmatic(
+                "security:scan",
+                provider="test.module:MockPluginValidator",
+            )
+
+            assert is_prog is True
+
+    def test_is_programmatic_unknown_defaults_false(self):
+        """Test is_programmatic defaults to False for unknown validators."""
+        registry = ValidatorRegistry()
+
+        # Unknown validator without provider
+        assert registry.is_programmatic("unknown:type") is False
+
+
+class TestPluginExecution:
+    """Tests for executing validation with plugin validators."""
+
+    @pytest.fixture
+    def sample_bundle(self, tmp_path):
+        """Create a sample document bundle."""
+        return DocumentBundle(
+            bundle_id="test-bundle",
+            bundle_type="test",
+            bundle_strategy="collection",
+            files=[],
+            project_path=tmp_path,
+        )
+
+    def test_execute_plugin_rule(self, sample_bundle):
+        """Test executing a validation rule with a plugin validator."""
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockPluginValidator = MockPluginValidator
+            mock_import.return_value = mock_module
+
+            rule = ValidationRule(
+                rule_type="security:scan",
+                description="Security scan",
+                failure_message="Security issue found",
+                expected_behavior="No security issues",
+            )
+
+            result = registry.execute_rule(
+                rule=rule,
+                bundle=sample_bundle,
+                provider="test.module:MockPluginValidator",
+            )
+
+            # MockPluginValidator always returns None (pass)
+            assert result is None
+
+    def test_execute_plugin_rule_with_failure(self, sample_bundle):
+        """Test executing a plugin rule that fails validation."""
+
+        class FailingValidator(BaseValidator):
+            @property
+            def validation_type(self) -> str:
+                return "security:fail"
+
+            @property
+            def computation_type(self) -> Literal["programmatic", "llm"]:
+                return "programmatic"
+
+            def validate(
+                self,
+                rule: ValidationRule,
+                bundle: DocumentBundle,
+                all_bundles: Optional[List[DocumentBundle]] = None,
+            ) -> Optional[DocumentRule]:
+                # Always fails
+                return DocumentRule(
+                    bundle_id=bundle.bundle_id,
+                    bundle_type=bundle.bundle_type,
+                    file_paths=[],
+                    observed_issue=rule.failure_message,
+                    expected_quality=rule.expected_behavior,
+                    rule_type="",
+                    context=f"Validation rule: {rule.description}",
+                )
+
+        registry = ValidatorRegistry()
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = MagicMock()
+            mock_module.FailingValidator = FailingValidator
+            mock_import.return_value = mock_module
+
+            rule = ValidationRule(
+                rule_type="security:fail",
+                description="Security scan",
+                failure_message="Security issue found",
+                expected_behavior="No security issues",
+            )
+
+            result = registry.execute_rule(
+                rule=rule,
+                bundle=sample_bundle,
+                provider="test.module:FailingValidator",
+            )
+
+            assert result is not None
+            assert result.observed_issue == "Security issue found"
+            assert result.expected_quality == "No security issues"
+
+
+class TestBuiltinValidatorMigration:
+    """Tests that all built-in validators use core: prefix."""
+
+    def test_all_builtin_validators_registered(self):
+        """Test that all 19 core validators are registered with core: prefix."""
+        registry = ValidatorRegistry()
+
+        expected_core_validators = [
+            "core:file_exists",
+            "core:file_size",
+            "core:token_count",
+            "core:json_schema",
+            "core:yaml_schema",
+            "core:yaml_frontmatter",
+            "core:regex_match",
+            "core:list_match",
+            "core:list_regex_match",
+            "core:markdown_link",
+            "core:dependency_duplicate",
+            "core:circular_dependencies",
+            "core:max_dependency_depth",
+            "core:claude_dependency_duplicate",
+            "core:claude_circular_dependencies",
+            "core:claude_max_dependency_depth",
+            "core:claude_skill_settings",
+            "core:claude_settings_duplicates",
+            "core:claude_mcp_permissions",
+        ]
+
+        for validator_type in expected_core_validators:
+            assert validator_type in registry._validators, f"{validator_type} not registered"
+
+        # Ensure count matches
+        assert len(registry._validators) == len(expected_core_validators)
+
+    def test_no_builtin_validators_without_namespace(self):
+        """Test that no built-in validators are registered without namespace."""
+        registry = ValidatorRegistry()
+
+        # All registered validators should have the namespace:type format
+        for validator_type in registry._validators.keys():
+            assert ":" in validator_type, f"{validator_type} missing namespace"
+            namespace, type_name = validator_type.split(":", 1)
+            assert namespace in ["core"], f"Unexpected namespace: {namespace}"
+
+    def test_builtin_validators_work_correctly(self, tmp_path):
+        """Test that built-in validators still work with new namespaced types."""
+        registry = ValidatorRegistry()
+
+        # Create a test file
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello, World!")
+
+        bundle = DocumentBundle(
+            bundle_id="test-bundle",
+            bundle_type="test",
+            bundle_strategy="collection",
+            files=[],
+            project_path=tmp_path,
+        )
+
+        # Test core:file_exists
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check test file exists",
+            file_path="test.txt",
+            failure_message="File not found",
+            expected_behavior="File should exist",
+        )
+
+        result = registry.execute_rule(rule, bundle)
+        assert result is None  # File exists, should pass
+
+        # Test core:file_exists with missing file
+        rule_missing = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check missing file",
+            file_path="missing.txt",
+            failure_message="Missing file not found",
+            expected_behavior="File should exist",
+        )
+
+        result_missing = registry.execute_rule(rule_missing, bundle)
+        assert result_missing is not None  # File doesn't exist, should fail

--- a/tests/unit/test_regex_match_validator.py
+++ b/tests/unit/test_regex_match_validator.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators.core.regex_validators import RegexMatchValidator
 
@@ -45,7 +45,7 @@ class TestRegexMatchValidator:
     def test_regex_match_passes(self, validator, bundle_with_file):
         """Test that validation passes when pattern matches."""
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Check for Prerequisites section",
             file_path="test.md",
             pattern=r"## Prerequisites",
@@ -59,7 +59,7 @@ class TestRegexMatchValidator:
     def test_regex_match_fails(self, validator, bundle_with_file):
         """Test that validation fails when pattern doesn't match."""
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Check for Installation section",
             file_path="test.md",
             pattern=r"## Installation",
@@ -92,7 +92,7 @@ class TestRegexMatchValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Match line start",
             file_path="test.txt",
             pattern=r"^Second",
@@ -107,7 +107,7 @@ class TestRegexMatchValidator:
     def test_regex_match_file_not_found(self, validator, bundle_with_file):
         """Test validation when file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Check nonexistent file",
             file_path="nonexistent.md",
             pattern=r"test",
@@ -123,7 +123,7 @@ class TestRegexMatchValidator:
     def test_regex_match_without_file_path_validates_bundle(self, validator, bundle_with_file):
         """Test that validator validates all files in bundle when file_path is not specified."""
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Check all files in bundle",
             pattern=r"## Prerequisites",
             failure_message="Missing Prerequisites section",
@@ -145,7 +145,7 @@ class TestRegexMatchValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Check empty bundle",
             pattern=r"test",
             failure_message="Pattern not found",
@@ -183,7 +183,7 @@ class TestRegexMatchValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Check for Prerequisites in all files",
             pattern=r"## Prerequisites",
             failure_message="Missing Prerequisites section",
@@ -199,7 +199,7 @@ class TestRegexMatchValidator:
     def test_regex_match_missing_pattern(self, validator, bundle_with_file):
         """Test that validator raises error when pattern is missing."""
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="No pattern",
             file_path="test.md",
             failure_message="Error",
@@ -216,7 +216,7 @@ class TestRegexMatchValidator:
 
         with pytest.raises(ValidationError, match="Invalid regex pattern"):
             ValidationRule(
-                rule_type=ValidationType.REGEX_MATCH,
+                rule_type="core:regex_match",
                 description="Invalid regex",
                 file_path="test.md",
                 pattern=r"[invalid(regex",  # Unclosed bracket
@@ -246,7 +246,7 @@ class TestRegexMatchValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Read protected file",
             file_path="test.md",
             pattern=r"test",
@@ -288,7 +288,7 @@ class TestRegexMatchValidator:
 
         # Should not match (case-sensitive)
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Case-sensitive match",
             file_path="test.md",
             pattern=r"hello",
@@ -320,7 +320,7 @@ class TestRegexMatchValidator:
 
         # Should match with IGNORECASE
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Case-insensitive match",
             file_path="test.md",
             pattern=r"hello",

--- a/tests/unit/test_rule_client_filtering.py
+++ b/tests/unit/test_rule_client_filtering.py
@@ -11,7 +11,6 @@ from drift.config.models import (
     RuleDefinition,
     ValidationRule,
     ValidationRulesConfig,
-    ValidationType,
 )
 from drift.core.analyzer import _get_supported_clients_from_rule
 from drift.validation.validators import ValidatorRegistry
@@ -40,7 +39,7 @@ class TestRuleClientFiltering:
                 ),
                 rules=[
                     ValidationRule(
-                        rule_type=ValidationType.FILE_EXISTS,
+                        rule_type="core:file_exists",
                         file_path="test.txt",
                         description="Test",
                         failure_message="Fail",
@@ -72,14 +71,14 @@ class TestRuleClientFiltering:
                 ),
                 rules=[
                     ValidationRule(
-                        rule_type=ValidationType.FILE_EXISTS,
+                        rule_type="core:file_exists",
                         file_path="test.txt",
                         description="Test",
                         failure_message="Fail",
                         expected_behavior="Pass",
                     ),
                     ValidationRule(
-                        rule_type=ValidationType.REGEX_MATCH,
+                        rule_type="core:regex_match",
                         pattern="test",
                         description="Test",
                         failure_message="Fail",
@@ -111,7 +110,7 @@ class TestRuleClientFiltering:
                 ),
                 rules=[
                     ValidationRule(
-                        rule_type=ValidationType.CLAUDE_SKILL_SETTINGS,
+                        rule_type="core:claude_skill_settings",
                         description="Test",
                         failure_message="Fail",
                         expected_behavior="Pass",
@@ -142,14 +141,14 @@ class TestRuleClientFiltering:
                 ),
                 rules=[
                     ValidationRule(
-                        rule_type=ValidationType.FILE_EXISTS,  # Supports ALL
+                        rule_type="core:file_exists",  # Supports ALL
                         file_path="test.txt",
                         description="Test",
                         failure_message="Fail",
                         expected_behavior="Pass",
                     ),
                     ValidationRule(
-                        rule_type=ValidationType.CLAUDE_SKILL_SETTINGS,  # Claude only
+                        rule_type="core:claude_skill_settings",  # Claude only
                         description="Test",
                         failure_message="Fail",
                         expected_behavior="Pass",

--- a/tests/unit/test_token_count_validator.py
+++ b/tests/unit/test_token_count_validator.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators.core.file_validators import TokenCountValidator
 
@@ -67,7 +67,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check CLAUDE.md token count",
             file_path="CLAUDE.md",
             max_count=1500,
@@ -118,7 +118,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check CLAUDE.md token count",
             file_path="CLAUDE.md",
             max_count=1500,
@@ -172,7 +172,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=1000,
@@ -222,7 +222,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=100,
@@ -263,7 +263,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=100,
@@ -307,7 +307,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=1000,
@@ -357,7 +357,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=100,
@@ -398,7 +398,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=1000,
@@ -420,7 +420,7 @@ class TestTokenCountValidator:
     def test_unsupported_provider(self, validator, bundle_with_file):
         """Test that validation fails with unsupported provider."""
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=1000,
@@ -454,7 +454,7 @@ class TestTokenCountValidator:
 
         # Rule without params (should default to anthropic)
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check token count",
             file_path="test.md",
             max_count=1000,
@@ -477,7 +477,7 @@ class TestTokenCountValidator:
     def test_file_not_found(self, validator, bundle_with_file):
         """Test validation when file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check nonexistent file",
             file_path="nonexistent.md",
             max_count=1000,
@@ -494,7 +494,7 @@ class TestTokenCountValidator:
     def test_missing_file_path(self, validator, bundle_with_file):
         """Test that validator raises error when file_path is missing."""
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="No file path",
             max_count=1000,
             params={"provider": "anthropic"},
@@ -526,7 +526,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Read protected file",
             file_path="test.md",
             max_count=1000,
@@ -564,7 +564,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check minimum tokens",
             file_path="test.md",
             min_count=100,
@@ -603,7 +603,7 @@ class TestTokenCountValidator:
     def test_no_constraints_passes(self, validator, bundle_with_file, monkeypatch):
         """Test that validation passes when no constraints are specified."""
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="No constraints",
             file_path="test.md",
             params={"provider": "anthropic"},
@@ -643,7 +643,7 @@ class TestTokenCountValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.TOKEN_COUNT,
+            rule_type="core:token_count",
             description="Check tokens",
             file_path="test.md",
             max_count=1000,

--- a/tests/unit/test_validator_client_support.py
+++ b/tests/unit/test_validator_client_support.py
@@ -6,7 +6,7 @@ to declare which client types they support (ALL, CLAUDE, etc.).
 
 import pytest
 
-from drift.config.models import ClientType, ValidationType
+from drift.config.models import ClientType
 from drift.validation.validators import ValidatorRegistry
 
 
@@ -19,13 +19,13 @@ class TestValidatorClientSupport:
 
         # All core validators should support ALL clients
         core_validators = [
-            ValidationType.FILE_EXISTS,
-            ValidationType.FILE_NOT_EXISTS,
-            ValidationType.REGEX_MATCH,
-            ValidationType.LIST_MATCH,
-            ValidationType.LIST_REGEX_MATCH,
-            ValidationType.DEPENDENCY_DUPLICATE,
-            ValidationType.MARKDOWN_LINK,
+            "core:file_exists",
+            "core:file_exists",
+            "core:regex_match",
+            "core:list_match",
+            "core:list_regex_match",
+            "core:dependency_duplicate",
+            "core:markdown_link",
         ]
 
         for rule_type in core_validators:
@@ -37,7 +37,7 @@ class TestValidatorClientSupport:
         """Test that Claude-specific validators only support CLAUDE client."""
         registry = ValidatorRegistry()
 
-        clients = registry.get_supported_clients(ValidationType.CLAUDE_SKILL_SETTINGS)
+        clients = registry.get_supported_clients("core:claude_skill_settings")
         assert ClientType.CLAUDE in clients
         assert ClientType.ALL not in clients
         assert len(clients) == 1
@@ -47,28 +47,28 @@ class TestValidatorClientSupport:
         registry = ValidatorRegistry()
 
         # Validators with ALL support should support any client type
-        assert registry.supports_client(ValidationType.REGEX_MATCH, ClientType.ALL)
-        assert registry.supports_client(ValidationType.REGEX_MATCH, ClientType.CLAUDE)
+        assert registry.supports_client("core:regex_match", ClientType.ALL)
+        assert registry.supports_client("core:regex_match", ClientType.CLAUDE)
 
     def test_supports_client_with_specific_type(self):
         """Test supports_client method for client-specific validators."""
         registry = ValidatorRegistry()
 
         # Claude-specific validator should only support CLAUDE
-        assert registry.supports_client(ValidationType.CLAUDE_SKILL_SETTINGS, ClientType.CLAUDE)
-        assert not registry.supports_client(ValidationType.CLAUDE_SKILL_SETTINGS, ClientType.ALL)
+        assert registry.supports_client("core:claude_skill_settings", ClientType.CLAUDE)
+        assert not registry.supports_client("core:claude_skill_settings", ClientType.ALL)
 
     def test_get_supported_clients_invalid_type(self):
         """Test get_supported_clients raises error for invalid rule type."""
         registry = ValidatorRegistry()
 
         with pytest.raises(ValueError, match="Unsupported validation rule type"):
-            # FILE_COUNT is not implemented yet
-            registry.get_supported_clients(ValidationType.FILE_COUNT)
+            # Use an actually invalid type
+            registry.get_supported_clients("invalid:nonexistent_type")
 
     def test_supports_client_invalid_type(self):
         """Test supports_client returns False for invalid rule type."""
         registry = ValidatorRegistry()
 
         # Should return False for unknown rule types instead of raising
-        assert not registry.supports_client(ValidationType.FILE_COUNT, ClientType.CLAUDE)
+        assert not registry.supports_client("invalid:nonexistent_type", ClientType.CLAUDE)

--- a/tests/unit/test_validator_computation_type.py
+++ b/tests/unit/test_validator_computation_type.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from drift.config.models import ValidationType
 from drift.validation.validators import ValidatorRegistry
 from drift.validation.validators.base import BaseValidator
 from drift.validation.validators.client import ClaudeSkillSettingsValidator
@@ -55,14 +54,14 @@ def test_registry_get_computation_type():
     registry = ValidatorRegistry()
 
     # Test all registered types
-    assert registry.get_computation_type(ValidationType.FILE_EXISTS) == "programmatic"
-    assert registry.get_computation_type(ValidationType.FILE_NOT_EXISTS) == "programmatic"
-    assert registry.get_computation_type(ValidationType.REGEX_MATCH) == "programmatic"
-    assert registry.get_computation_type(ValidationType.LIST_MATCH) == "programmatic"
-    assert registry.get_computation_type(ValidationType.LIST_REGEX_MATCH) == "programmatic"
-    assert registry.get_computation_type(ValidationType.DEPENDENCY_DUPLICATE) == "programmatic"
-    assert registry.get_computation_type(ValidationType.MARKDOWN_LINK) == "programmatic"
-    assert registry.get_computation_type(ValidationType.CLAUDE_SKILL_SETTINGS) == "programmatic"
+    assert registry.get_computation_type("core:file_exists") == "programmatic"
+    assert registry.get_computation_type("core:file_exists") == "programmatic"
+    assert registry.get_computation_type("core:regex_match") == "programmatic"
+    assert registry.get_computation_type("core:list_match") == "programmatic"
+    assert registry.get_computation_type("core:list_regex_match") == "programmatic"
+    assert registry.get_computation_type("core:dependency_duplicate") == "programmatic"
+    assert registry.get_computation_type("core:markdown_link") == "programmatic"
+    assert registry.get_computation_type("core:claude_skill_settings") == "programmatic"
 
 
 def test_registry_is_programmatic():
@@ -70,8 +69,8 @@ def test_registry_is_programmatic():
     registry = ValidatorRegistry()
 
     # All current validators should be programmatic
-    assert registry.is_programmatic(ValidationType.FILE_EXISTS) is True
-    assert registry.is_programmatic(ValidationType.CLAUDE_SKILL_SETTINGS) is True
+    assert registry.is_programmatic("core:file_exists") is True
+    assert registry.is_programmatic("core:claude_skill_settings") is True
 
 
 def test_base_validator_abstract_computation_type():

--- a/tests/unit/test_validator_default_messages.py
+++ b/tests/unit/test_validator_default_messages.py
@@ -1,0 +1,470 @@
+"""Unit tests for validator default failure message functionality."""
+
+from typing import List, Literal, Optional
+
+import pytest
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentRule
+from drift.validation.validators import (
+    BaseValidator,
+    CircularDependenciesValidator,
+    FileExistsValidator,
+)
+
+
+class MockValidatorWithDefaults(BaseValidator):
+    """Mock validator with custom default messages for testing."""
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type."""
+        return "test:mock_validator"
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type."""
+        return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message."""
+        return "Default failure: {detail}"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior."""
+        return "Default expected behavior"
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Mock validation that always fails for testing."""
+        failure_details = {"detail": "test_value"}
+
+        return DocumentRule(
+            bundle_id=bundle.bundle_id,
+            bundle_type=bundle.bundle_type,
+            file_paths=[],
+            observed_issue=self._get_failure_message(rule, failure_details),
+            expected_quality=self._get_expected_behavior(rule),
+            rule_type="",
+            context=f"Test: {rule.description}",
+            failure_details=failure_details,
+        )
+
+
+class TestBaseValidatorDefaultMessages:
+    """Tests for BaseValidator default message functionality."""
+
+    def test_default_failure_message_generic(self):
+        """Test that BaseValidator provides a generic default message."""
+        validator = FileExistsValidator()
+        assert (
+            "core:file_exists" in validator.default_failure_message
+            or "File" in validator.default_failure_message
+        )
+
+    def test_default_expected_behavior_generic(self):
+        """Test that BaseValidator provides a generic default expected behavior."""
+        validator = FileExistsValidator()
+        assert validator.default_expected_behavior is not None
+        assert len(validator.default_expected_behavior) > 0
+
+    def test_get_failure_message_uses_custom_when_provided(self):
+        """Test that _get_failure_message uses custom message when provided."""
+        validator = MockValidatorWithDefaults()
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test rule",
+            failure_message="Custom: {detail}",
+        )
+
+        message = validator._get_failure_message(rule, {"detail": "foo"})
+        assert message == "Custom: foo"
+
+    def test_get_failure_message_uses_default_when_none(self):
+        """Test that _get_failure_message uses default when None."""
+        validator = MockValidatorWithDefaults()
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test rule",
+            failure_message=None,
+        )
+
+        message = validator._get_failure_message(rule, {"detail": "bar"})
+        assert message == "Default failure: bar"
+
+    def test_get_expected_behavior_uses_custom_when_provided(self):
+        """Test that _get_expected_behavior uses custom when provided."""
+        validator = MockValidatorWithDefaults()
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test rule",
+            expected_behavior="Custom expected",
+        )
+
+        behavior = validator._get_expected_behavior(rule)
+        assert behavior == "Custom expected"
+
+    def test_get_expected_behavior_uses_default_when_none(self):
+        """Test that _get_expected_behavior uses default when None."""
+        validator = MockValidatorWithDefaults()
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test rule",
+            expected_behavior=None,
+        )
+
+        behavior = validator._get_expected_behavior(rule)
+        assert behavior == "Default expected behavior"
+
+
+class TestFileExistsValidatorDefaultMessages:
+    """Tests for FileExistsValidator default messages."""
+
+    @pytest.fixture
+    def bundle_with_missing_file(self, tmp_path):
+        """Create bundle with a missing file."""
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            files=[],
+            project_path=tmp_path,
+        )
+
+    def test_file_exists_has_default_message(self):
+        """Test that FileExistsValidator has a default failure message."""
+        validator = FileExistsValidator()
+        assert validator.default_failure_message is not None
+        assert (
+            "file" in validator.default_failure_message.lower()
+            or "exist" in validator.default_failure_message.lower()
+        )
+
+    def test_file_exists_has_default_expected_behavior(self):
+        """Test that FileExistsValidator has a default expected behavior."""
+        validator = FileExistsValidator()
+        assert validator.default_expected_behavior is not None
+        assert len(validator.default_expected_behavior) > 0
+
+    def test_file_exists_uses_default_message_when_none(self, bundle_with_missing_file):
+        """Test that FileExistsValidator uses default message when none provided."""
+        validator = FileExistsValidator()
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check file",
+            file_path="missing.txt",
+            failure_message=None,  # No custom message
+            expected_behavior=None,  # No custom behavior
+        )
+
+        result = validator.validate(rule, bundle_with_missing_file)
+
+        assert result is not None
+        # Should use default message
+        assert result.observed_issue is not None
+        assert "missing.txt" in result.observed_issue
+        # Should use default expected behavior
+        assert result.expected_quality is not None
+
+    def test_file_exists_uses_custom_message_when_provided(self, bundle_with_missing_file):
+        """Test that FileExistsValidator uses custom message when provided."""
+        validator = FileExistsValidator()
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check file",
+            file_path="missing.txt",
+            failure_message="Custom: File {file_path} is missing!",
+            expected_behavior="Custom: File should exist",
+        )
+
+        result = validator.validate(rule, bundle_with_missing_file)
+
+        assert result is not None
+        assert result.observed_issue == "Custom: File missing.txt is missing!"
+        assert result.expected_quality == "Custom: File should exist"
+
+
+class TestCircularDependenciesValidatorDefaultMessages:
+    """Tests for CircularDependenciesValidator default messages."""
+
+    def test_circular_deps_has_default_message(self):
+        """Test that CircularDependenciesValidator has a default message."""
+        validator = CircularDependenciesValidator()
+        assert validator.default_failure_message is not None
+        assert (
+            "circular" in validator.default_failure_message.lower()
+            or "cycle" in validator.default_failure_message.lower()
+        )
+
+    def test_circular_deps_has_default_expected_behavior(self):
+        """Test that CircularDependenciesValidator has default expected behavior."""
+        validator = CircularDependenciesValidator()
+        assert validator.default_expected_behavior is not None
+        assert len(validator.default_expected_behavior) > 0
+
+    def test_circular_deps_default_message_has_placeholder(self):
+        """Test that default message includes placeholder for circular path."""
+        validator = CircularDependenciesValidator()
+        assert "{circular_path}" in validator.default_failure_message
+
+
+class TestValidationRuleOptionalMessages:
+    """Tests for ValidationRule with optional failure messages."""
+
+    def test_validation_rule_with_no_messages(self):
+        """Test creating ValidationRule with no failure_message or expected_behavior."""
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Test rule",
+            file_path="test.txt",
+        )
+
+        assert rule.failure_message is None
+        assert rule.expected_behavior is None
+
+    def test_validation_rule_with_only_failure_message(self):
+        """Test creating ValidationRule with only failure_message."""
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Test rule",
+            file_path="test.txt",
+            failure_message="Custom failure",
+        )
+
+        assert rule.failure_message == "Custom failure"
+        assert rule.expected_behavior is None
+
+    def test_validation_rule_with_only_expected_behavior(self):
+        """Test creating ValidationRule with only expected_behavior."""
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Test rule",
+            file_path="test.txt",
+            expected_behavior="Custom expected",
+        )
+
+        assert rule.failure_message is None
+        assert rule.expected_behavior == "Custom expected"
+
+    def test_validation_rule_with_both_messages(self):
+        """Test creating ValidationRule with both messages."""
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Test rule",
+            file_path="test.txt",
+            failure_message="Custom failure",
+            expected_behavior="Custom expected",
+        )
+
+        assert rule.failure_message == "Custom failure"
+        assert rule.expected_behavior == "Custom expected"
+
+
+class TestDefaultMessageTemplateSubstitution:
+    """Tests for template substitution in default messages."""
+
+    def test_template_substitution_with_details(self):
+        """Test that default messages support template substitution."""
+        validator = MockValidatorWithDefaults()
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test",
+            failure_message=None,  # Use default
+        )
+
+        # Default is "Default failure: {detail}"
+        message = validator._get_failure_message(rule, {"detail": "test123"})
+        assert message == "Default failure: test123"
+
+    def test_template_substitution_without_details(self):
+        """Test that templates without details don't break."""
+        validator = MockValidatorWithDefaults()
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test",
+            failure_message=None,
+        )
+
+        # Default has {detail} but we don't provide it
+        message = validator._get_failure_message(rule, None)
+        # Placeholder should remain unchanged
+        assert "{detail}" in message
+
+    def test_custom_template_with_multiple_placeholders(self):
+        """Test custom message with multiple placeholders."""
+        validator = MockValidatorWithDefaults()
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test",
+            failure_message="Error in {file} at line {line}",
+        )
+
+        message = validator._get_failure_message(rule, {"file": "test.py", "line": "42"})
+        assert message == "Error in test.py at line 42"
+
+
+class TestEndToEndDefaultMessages:
+    """End-to-end tests for default message functionality."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create mock validator instance."""
+        return MockValidatorWithDefaults()
+
+    @pytest.fixture
+    def bundle(self, tmp_path):
+        """Create test document bundle."""
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            files=[],
+            project_path=tmp_path,
+        )
+
+    def test_e2e_with_no_custom_messages(self, validator, bundle):
+        """Test end-to-end flow with no custom messages."""
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test rule",
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert result.observed_issue == "Default failure: test_value"
+        assert result.expected_quality == "Default expected behavior"
+        assert result.failure_details == {"detail": "test_value"}
+
+    def test_e2e_with_custom_messages(self, validator, bundle):
+        """Test end-to-end flow with custom messages."""
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test rule",
+            failure_message="CUSTOM: {detail}",
+            expected_behavior="CUSTOM EXPECTED",
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert result.observed_issue == "CUSTOM: test_value"
+        assert result.expected_quality == "CUSTOM EXPECTED"
+
+    def test_e2e_with_partial_custom_messages(self, validator, bundle):
+        """Test end-to-end flow with only failure_message custom."""
+        rule = ValidationRule(
+            rule_type="test:mock",
+            description="Test rule",
+            failure_message="CUSTOM: {detail}",
+            # expected_behavior not provided - should use default
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert result.observed_issue == "CUSTOM: test_value"
+        assert result.expected_quality == "Default expected behavior"  # Uses default
+
+
+class TestBaseValidatorFallbacks:
+    """Test BaseValidator fallback behavior when not overridden."""
+
+    def test_base_validator_default_failure_message_fallback(self, tmp_path):
+        """Verify BaseValidator provides generic fallback when not overridden."""
+
+        class MinimalValidator(BaseValidator):
+            """Validator that doesn't override default messages."""
+
+            @property
+            def validation_type(self) -> str:
+                """Return validation type."""
+                return "test:minimal"
+
+            @property
+            def computation_type(self) -> Literal["programmatic", "llm"]:
+                """Return computation type."""
+                return "programmatic"
+
+            def validate(self, rule, bundle, all_bundles=None):
+                """Fail validation for testing purposes."""
+                return DocumentRule(
+                    bundle_id=bundle.bundle_id,
+                    bundle_type=bundle.bundle_type,
+                    file_paths=[],
+                    observed_issue=self._get_failure_message(rule),
+                    expected_quality=self._get_expected_behavior(rule),
+                    rule_type="",
+                    context="Test",
+                )
+
+        validator = MinimalValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[],
+        )
+        rule = ValidationRule(rule_type="test:minimal", description="Test")
+
+        result = validator.validate(rule, bundle)
+
+        # Should use BaseValidator's generic fallbacks
+        assert result.observed_issue == "Validation failed for test:minimal"
+        assert result.expected_quality == "Should pass test:minimal validation"
+
+    def test_base_validator_fallback_with_custom_message(self, tmp_path):
+        """Verify BaseValidator fallback with custom message in rule."""
+
+        class MinimalValidator(BaseValidator):
+            """Validator that doesn't override default messages."""
+
+            @property
+            def validation_type(self) -> str:
+                """Return validation type."""
+                return "test:minimal"
+
+            @property
+            def computation_type(self) -> Literal["programmatic", "llm"]:
+                """Return computation type."""
+                return "programmatic"
+
+            def validate(self, rule, bundle, all_bundles=None):
+                """Fail validation for testing purposes."""
+                return DocumentRule(
+                    bundle_id=bundle.bundle_id,
+                    bundle_type=bundle.bundle_type,
+                    file_paths=[],
+                    observed_issue=self._get_failure_message(rule),
+                    expected_quality=self._get_expected_behavior(rule),
+                    rule_type="",
+                    context="Test",
+                )
+
+        validator = MinimalValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[],
+        )
+        rule = ValidationRule(
+            rule_type="test:minimal",
+            description="Test",
+            failure_message="Custom failure",
+            expected_behavior="Custom expected",
+        )
+
+        result = validator.validate(rule, bundle)
+
+        # Should use custom messages from rule
+        assert result.observed_issue == "Custom failure"
+        assert result.expected_quality == "Custom expected"

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -10,7 +10,6 @@ from drift.config.models import (
     DocumentBundleConfig,
     ValidationRule,
     ValidationRulesConfig,
-    ValidationType,
 )
 from drift.core.types import DocumentBundle
 from drift.validation.validators import FileExistsValidator, ValidatorRegistry
@@ -22,56 +21,56 @@ class TestValidationRule:
     def test_valid_file_exists_rule(self):
         """Test creating a valid file existence rule."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Check CLAUDE.md exists",
             file_path="CLAUDE.md",
             failure_message="CLAUDE.md not found",
             expected_behavior="CLAUDE.md should exist",
         )
-        assert rule.rule_type == ValidationType.FILE_EXISTS
+        assert rule.rule_type == "core:file_exists"
         assert rule.file_path == "CLAUDE.md"
         assert rule.pattern is None
 
     def test_valid_regex_rule(self):
         """Test creating a valid regex matching rule."""
         rule = ValidationRule(
-            rule_type=ValidationType.REGEX_MATCH,
+            rule_type="core:regex_match",
             description="Check for Prerequisites section",
             pattern=r"^## Prerequisites",
             flags=re.MULTILINE,
             failure_message="Missing Prerequisites section",
             expected_behavior="Should have Prerequisites section",
         )
-        assert rule.rule_type == ValidationType.REGEX_MATCH
+        assert rule.rule_type == "core:regex_match"
         assert rule.pattern == r"^## Prerequisites"
         assert rule.flags == re.MULTILINE
 
-    def test_valid_file_count_rule(self):
-        """Test creating a valid file count rule."""
+    def test_valid_file_size_rule(self):
+        """Test creating a valid file size rule."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_COUNT,
-            description="Limit number of commands",
-            file_path=".claude/commands/*.md",
+            rule_type="core:file_size",
+            description="Limit number of lines in commands",
+            file_path=".claude/commands/test.md",
             max_count=20,
-            failure_message="Too many commands",
-            expected_behavior="Should have <= 20 commands",
+            failure_message="Too many lines",
+            expected_behavior="Should have <= 20 lines",
         )
-        assert rule.rule_type == ValidationType.FILE_COUNT
+        assert rule.rule_type == "core:file_size"
         assert rule.max_count == 20
         assert rule.min_count is None
 
-    def test_valid_cross_file_reference_rule(self):
-        """Test creating a valid cross-file reference rule."""
+    def test_valid_markdown_link_rule(self):
+        """Test creating a valid markdown link validation rule."""
         rule = ValidationRule(
-            rule_type=ValidationType.CROSS_FILE_REFERENCE,
-            description="Check skill references",
+            rule_type="core:markdown_link",
+            description="Check markdown links",
             source_pattern=".claude/commands/*.md",
             reference_pattern=r"\[([^\]]+)\]\(.*?/skills/([^/]+)/SKILL\.md\)",
             target_pattern=".claude/skills/*/SKILL.md",
             failure_message="Broken skill reference",
             expected_behavior="All references should be valid",
         )
-        assert rule.rule_type == ValidationType.CROSS_FILE_REFERENCE
+        assert rule.rule_type == "core:markdown_link"
         assert rule.source_pattern == ".claude/commands/*.md"
         assert rule.reference_pattern is not None
 
@@ -79,7 +78,7 @@ class TestValidationRule:
         """Test that invalid regex pattern raises ValidationError."""
         with pytest.raises(ValidationError) as exc_info:
             ValidationRule(
-                rule_type=ValidationType.REGEX_MATCH,
+                rule_type="core:regex_match",
                 description="Invalid regex",
                 pattern=r"[invalid(regex",  # Unclosed bracket
                 failure_message="Test",
@@ -91,7 +90,7 @@ class TestValidationRule:
         """Test that invalid reference pattern raises ValidationError."""
         with pytest.raises(ValidationError) as exc_info:
             ValidationRule(
-                rule_type=ValidationType.CROSS_FILE_REFERENCE,
+                rule_type="core:markdown_link",
                 description="Invalid reference pattern",
                 reference_pattern=r"[invalid(regex",  # Unclosed bracket
                 failure_message="Test",
@@ -106,7 +105,7 @@ class TestValidationRulesConfig:
     def test_valid_validation_rules_config(self):
         """Test creating a valid validation rules configuration."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test rule",
             file_path="test.md",
             failure_message="Test failure",
@@ -132,7 +131,7 @@ class TestValidationRulesConfig:
     def test_default_scope(self):
         """Test default scope is document_level."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Test",
             file_path="test.md",
             failure_message="Test",
@@ -156,14 +155,14 @@ class TestValidationRulesConfig:
         """Test validation config with multiple rules."""
         rules = [
             ValidationRule(
-                rule_type=ValidationType.FILE_EXISTS,
+                rule_type="core:file_exists",
                 description="Rule 1",
                 file_path="test1.md",
                 failure_message="Test 1",
                 expected_behavior="Test 1",
             ),
             ValidationRule(
-                rule_type=ValidationType.FILE_EXISTS,
+                rule_type="core:file_exists",
                 description="Rule 2",
                 file_path="test2.md",
                 failure_message="Test 2",
@@ -216,7 +215,7 @@ class TestFileExistsValidator:
     def test_file_exists_passes(self, sample_bundle):
         """Test that validation passes when file exists."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Check README exists",
             file_path="README.md",
             failure_message="README not found",
@@ -231,7 +230,7 @@ class TestFileExistsValidator:
     def test_file_exists_fails(self, sample_bundle):
         """Test that validation fails when file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Check missing file",
             file_path="MISSING.md",
             failure_message="MISSING.md not found",
@@ -249,7 +248,7 @@ class TestFileExistsValidator:
     def test_glob_pattern_with_matches_passes(self, sample_bundle):
         """Test that glob pattern validation passes when files match."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Check skill files exist",
             file_path=".claude/skills/*/SKILL.md",
             failure_message="No skill files found",
@@ -264,7 +263,7 @@ class TestFileExistsValidator:
     def test_glob_pattern_no_matches_fails(self, sample_bundle):
         """Test that glob pattern validation fails when no files match."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Check missing pattern",
             file_path=".claude/commands/*.md",
             failure_message="No command files found",
@@ -280,7 +279,7 @@ class TestFileExistsValidator:
     def test_missing_file_path_raises_error(self, sample_bundle):
         """Test that validator raises error when file_path is None."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Missing file path",
             failure_message="Test",
             expected_behavior="Test",
@@ -317,13 +316,13 @@ class TestValidatorRegistry:
         """Test that registry initializes with validators."""
         registry = ValidatorRegistry()
 
-        assert ValidationType.FILE_EXISTS in registry._validators
-        assert ValidationType.FILE_NOT_EXISTS in registry._validators
+        assert "core:file_exists" in registry._validators
+        assert "core:regex_match" in registry._validators
 
     def test_execute_file_exists_rule(self, sample_bundle):
-        """Test executing FILE_EXISTS rule through registry."""
+        """Test executing core:file_exists rule through registry."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_EXISTS,
+            rule_type="core:file_exists",
             description="Check file exists",
             file_path="EXISTS.md",
             failure_message="File not found",
@@ -335,45 +334,47 @@ class TestValidatorRegistry:
 
         assert result is None  # File exists, validation passes
 
-    def test_execute_file_not_exists_rule_inverted(self, sample_bundle):
-        """Test that FILE_NOT_EXISTS inverts the result correctly."""
-        # File EXISTS.md exists, so FILE_NOT_EXISTS should fail
+    def test_execute_file_exists_with_missing_file_fails(self, sample_bundle):
+        """Test that core:file_exists fails when file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_NOT_EXISTS,
-            description="File should not exist",
-            file_path="EXISTS.md",
-            failure_message="File should not exist",
-            expected_behavior="File should be absent",
-        )
-
-        registry = ValidatorRegistry()
-        result = registry.execute_rule(rule, sample_bundle)
-
-        assert result is not None  # File exists but shouldn't, validation fails
-        assert result.observed_issue == "File should not exist"
-
-    def test_execute_file_not_exists_passes_when_missing(self, sample_bundle):
-        """Test that FILE_NOT_EXISTS passes when file is missing."""
-        # MISSING.md doesn't exist, so FILE_NOT_EXISTS should pass
-        rule = ValidationRule(
-            rule_type=ValidationType.FILE_NOT_EXISTS,
-            description="File should not exist",
+            rule_type="core:file_exists",
+            description="Check missing file",
             file_path="MISSING.md",
-            failure_message="File should not exist",
-            expected_behavior="File should be absent",
+            failure_message="File not found",
+            expected_behavior="File should exist",
         )
 
         registry = ValidatorRegistry()
         result = registry.execute_rule(rule, sample_bundle)
 
-        assert result is None  # File doesn't exist as desired, validation passes
+        assert result is not None  # File doesn't exist, validation fails
+        assert result.observed_issue == "File not found"
+
+    def test_execute_regex_match_rule(self, sample_bundle, tmp_path):
+        """Test executing core:regex_match rule through registry."""
+        # Create a test file with content
+        (sample_bundle.project_path / "test.txt").write_text("Hello World\nTest Pattern\n")
+
+        rule = ValidationRule(
+            rule_type="core:regex_match",
+            description="Check for pattern",
+            file_path="test.txt",
+            pattern=r"Test Pattern",
+            failure_message="Pattern not found",
+            expected_behavior="Pattern should exist",
+        )
+
+        registry = ValidatorRegistry()
+        result = registry.execute_rule(rule, sample_bundle)
+
+        assert result is None  # Pattern found, validation passes
 
     def test_unsupported_rule_type_raises_error(self, sample_bundle):
         """Test that unsupported rule types raise ValueError."""
-        # Create a rule with FILE_COUNT which we haven't implemented yet
+        # Create a rule with unknown type
         rule = ValidationRule(
-            rule_type=ValidationType.FILE_COUNT,
-            description="Test file count",
+            rule_type="custom:unknown",
+            description="Test unknown type",
             failure_message="Test",
             expected_behavior="Test",
         )

--- a/tests/unit/test_validators_default_messages_real.py
+++ b/tests/unit/test_validators_default_messages_real.py
@@ -1,0 +1,427 @@
+"""Tests for default messages in real validators.
+
+This module tests that all built-in validators properly implement and use
+their default failure messages and expected behaviors when no custom messages
+are provided in the validation rule.
+"""
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentFile
+from drift.validation.validators import (
+    CircularDependenciesValidator,
+    DependencyDuplicateValidator,
+    FileExistsValidator,
+    FileSizeValidator,
+    JsonSchemaValidator,
+    ListMatchValidator,
+    ListRegexMatchValidator,
+    MarkdownLinkValidator,
+    MaxDependencyDepthValidator,
+    RegexMatchValidator,
+    TokenCountValidator,
+    YamlFrontmatterValidator,
+    YamlSchemaValidator,
+)
+
+
+class TestFileExistsValidatorDefaults:
+    """Test FileExistsValidator default messages."""
+
+    def test_uses_default_when_file_not_exists(self, tmp_path):
+        """Test that FileExistsValidator uses default message when file doesn't exist."""
+        validator = FileExistsValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check file exists",
+            file_path="missing.txt",
+            # No failure_message or expected_behavior - should use defaults
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert "does not exist" in result.observed_issue.lower()
+        assert "should exist" in result.expected_quality.lower()
+
+    def test_uses_custom_messages_when_provided(self, tmp_path):
+        """Test that custom messages override defaults."""
+        validator = FileExistsValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check file exists",
+            file_path="missing.txt",
+            failure_message="CUSTOM: File {file_path} is missing!",
+            expected_behavior="CUSTOM: File must be present",
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert result.observed_issue == "CUSTOM: File missing.txt is missing!"
+        assert result.expected_quality == "CUSTOM: File must be present"
+
+
+class TestFileSizeValidatorDefaults:
+    """Test FileSizeValidator default messages."""
+
+    def test_file_size_validator_has_default_messages(self):
+        """Test that FileSizeValidator has default message properties."""
+        validator = FileSizeValidator()
+
+        # Verify default messages exist and are meaningful
+        assert hasattr(validator, "default_failure_message")
+        assert hasattr(validator, "default_expected_behavior")
+        assert validator.default_failure_message != ""
+        assert validator.default_expected_behavior != ""
+        assert (
+            "exceed" in validator.default_failure_message.lower()
+            or "size" in validator.default_failure_message.lower()
+        )
+        assert (
+            "exceed" in validator.default_expected_behavior.lower()
+            or "size" in validator.default_expected_behavior.lower()
+        )
+
+
+class TestRegexMatchValidatorDefaults:
+    """Test RegexMatchValidator default messages."""
+
+    def test_uses_default_when_pattern_not_found(self, tmp_path):
+        """Test RegexMatchValidator uses default when pattern not found."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello world")
+
+        validator = RegexMatchValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    file_path=str(test_file),
+                    relative_path="test.txt",
+                    content="Hello world",
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:regex_match",
+            description="Check pattern",
+            pattern=r"MISSING_PATTERN",
+            # No custom messages
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert "pattern" in result.observed_issue.lower()
+        assert "should match" in result.expected_quality.lower()
+
+
+class TestListMatchValidatorDefaults:
+    """Test ListMatchValidator default messages."""
+
+    def test_uses_default_when_items_missing(self, tmp_path):
+        """Test ListMatchValidator uses default when items missing."""
+        validator = ListMatchValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:list_match",
+            description="Check list items",
+            params={
+                "items": {"type": "string_list", "value": ["a", "b", "c"]},
+                "target": {"type": "string_list", "value": ["a", "b"]},  # Missing 'c'
+                "match_mode": "all_in",
+            },
+            # No custom messages
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert "validation failed" in result.observed_issue.lower()
+        assert "should match" in result.expected_quality.lower()
+
+
+class TestMarkdownLinkValidatorDefaults:
+    """Test MarkdownLinkValidator default messages."""
+
+    def test_uses_default_when_links_broken(self, tmp_path):
+        """Test MarkdownLinkValidator uses default when links broken."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("[Link](missing.md)")
+
+        validator = MarkdownLinkValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    file_path=str(md_file),
+                    relative_path="test.md",
+                    content="[Link](missing.md)",
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:markdown_link",
+            description="Check markdown links",
+            # No custom messages
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert "broken" in result.observed_issue.lower() or "link" in result.observed_issue.lower()
+
+
+class TestJsonSchemaValidatorDefaults:
+    """Test JsonSchemaValidator default messages."""
+
+    def test_uses_default_when_schema_validation_fails(self, tmp_path):
+        """Test JsonSchemaValidator uses default when validation fails."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"name": "test"}')
+
+        validator = JsonSchemaValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    file_path=str(json_file),
+                    relative_path="test.json",
+                    content='{"name": "test"}',
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:json_schema",
+            description="Validate JSON schema",
+            file_path="test.json",  # JsonSchemaValidator requires this
+            params={
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
+                    "required": ["name", "age"],  # Missing 'age'
+                }
+            },
+            # No custom messages
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert (
+            "schema" in result.observed_issue.lower()
+            or "validation" in result.observed_issue.lower()
+        )
+
+
+class TestYamlSchemaValidatorDefaults:
+    """Test YamlSchemaValidator default messages."""
+
+    def test_uses_default_when_schema_validation_fails(self, tmp_path):
+        """Test YamlSchemaValidator uses default when validation fails."""
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text("name: test\n")
+
+        validator = YamlSchemaValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    file_path=str(yaml_file),
+                    relative_path="test.yaml",
+                    content="name: test\n",
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:yaml_schema",
+            description="Validate YAML schema",
+            file_path="test.yaml",  # YamlSchemaValidator requires this
+            params={
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
+                    "required": ["name", "age"],  # Missing 'age'
+                }
+            },
+            # No custom messages
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert (
+            "schema" in result.observed_issue.lower()
+            or "validation" in result.observed_issue.lower()
+        )
+
+
+class TestYamlFrontmatterValidatorDefaults:
+    """Test YamlFrontmatterValidator default messages."""
+
+    def test_uses_default_when_frontmatter_invalid(self, tmp_path):
+        """Test YamlFrontmatterValidator uses default when frontmatter invalid."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text(
+            """---
+title: Test
+---
+Content
+"""
+        )
+
+        validator = YamlFrontmatterValidator()
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="test",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    file_path=str(md_file),
+                    relative_path="test.md",
+                    content="---\ntitle: Test\n---\nContent\n",
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:yaml_frontmatter",
+            description="Validate frontmatter",
+            params={
+                "schema": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}, "author": {"type": "string"}},
+                    "required": ["title", "author"],  # Missing 'author'
+                }
+            },
+            # No custom messages
+        )
+
+        result = validator.validate(rule, bundle)
+
+        assert result is not None
+        assert (
+            "frontmatter" in result.observed_issue.lower()
+            or "schema" in result.observed_issue.lower()
+        )
+
+
+class TestTokenCountValidatorDefaults:
+    """Test TokenCountValidator default messages."""
+
+    def test_token_count_default_properties_exist(self):
+        """Test that TokenCountValidator has default message properties."""
+        validator = TokenCountValidator()
+
+        # Verify default messages exist
+        assert hasattr(validator, "default_failure_message")
+        assert hasattr(validator, "default_expected_behavior")
+        assert "token" in validator.default_failure_message.lower()
+        assert (
+            "token" in validator.default_expected_behavior.lower()
+            or "exceed" in validator.default_expected_behavior.lower()
+        )
+
+
+class TestDependencyValidatorDefaults:
+    """Test dependency validator default messages."""
+
+    def test_circular_dependencies_default_properties(self):
+        """Test CircularDependenciesValidator has default message properties."""
+        validator = CircularDependenciesValidator()
+
+        assert hasattr(validator, "default_failure_message")
+        assert hasattr(validator, "default_expected_behavior")
+        assert (
+            "circular" in validator.default_failure_message.lower()
+            or "{circular_path}" in validator.default_failure_message
+        )
+        assert (
+            "circular" in validator.default_expected_behavior.lower()
+            or "no" in validator.default_expected_behavior.lower()
+        )
+
+    def test_dependency_duplicate_default_properties(self):
+        """Test DependencyDuplicateValidator has default message properties."""
+        validator = DependencyDuplicateValidator()
+
+        assert hasattr(validator, "default_failure_message")
+        assert hasattr(validator, "default_expected_behavior")
+        assert "duplicate" in validator.default_failure_message.lower()
+        assert (
+            "duplicate" in validator.default_expected_behavior.lower()
+            or "no" in validator.default_expected_behavior.lower()
+        )
+
+    def test_max_dependency_depth_default_properties(self):
+        """Test MaxDependencyDepthValidator has default message properties."""
+        validator = MaxDependencyDepthValidator()
+
+        assert hasattr(validator, "default_failure_message")
+        assert hasattr(validator, "default_expected_behavior")
+        assert (
+            "depth" in validator.default_failure_message.lower()
+            or "{actual_depth}" in validator.default_failure_message
+        )
+        assert (
+            "depth" in validator.default_expected_behavior.lower()
+            or "maximum" in validator.default_expected_behavior.lower()
+        )
+
+
+class TestListValidatorDefaults:
+    """Test list validator default messages."""
+
+    def test_list_match_default_properties(self):
+        """Test ListMatchValidator has default message properties."""
+        validator = ListMatchValidator()
+
+        assert hasattr(validator, "default_failure_message")
+        assert hasattr(validator, "default_expected_behavior")
+        assert validator.default_failure_message != ""
+        assert validator.default_expected_behavior != ""
+
+    def test_list_regex_match_validator_exists(self):
+        """Test ListRegexMatchValidator exists and has computation type."""
+        validator = ListRegexMatchValidator()
+        assert validator.computation_type == "programmatic"

--- a/tests/unit/test_validators_new.py
+++ b/tests/unit/test_validators_new.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators import ClaudeDependencyDuplicateValidator, MarkdownLinkValidator
 
@@ -50,7 +50,7 @@ class TestDependencyDuplicateValidator:
     def validation_rule(self):
         """Create a validation rule."""
         return ValidationRule(
-            rule_type=ValidationType.DEPENDENCY_DUPLICATE,
+            rule_type="core:dependency_duplicate",
             description="Check for duplicate dependencies",
             failure_message="Found duplicate dependencies",
             expected_behavior="No duplicate dependencies",
@@ -324,7 +324,7 @@ class TestMarkdownLinkValidator:
     def validation_rule(self):
         """Create a validation rule."""
         return ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check for broken links",
             failure_message="Found broken links",
             expected_behavior="All links should be valid",
@@ -486,7 +486,7 @@ class TestMarkdownLinkValidator:
 
         # Create rule with check_local_files disabled
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check for broken links",
             failure_message="Found broken links",
             expected_behavior="All links should be valid",
@@ -519,7 +519,7 @@ class TestMarkdownLinkValidator:
 
         # Create rule with check_external_urls disabled
         rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check for broken links",
             failure_message="Found broken links",
             expected_behavior="All links should be valid",
@@ -682,7 +682,7 @@ your-project/src/main.py
         """Test that custom skip patterns work through validator params."""
         # Create a rule with custom patterns
         validation_rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check for broken links",
             failure_message="Found broken links",
             expected_behavior="All links should be valid",
@@ -718,7 +718,7 @@ your-project/src/main.py
         """Test that filtering can be explicitly disabled."""
         # Create a rule with filtering disabled
         validation_rule = ValidationRule(
-            rule_type=ValidationType.MARKDOWN_LINK,
+            rule_type="core:markdown_link",
             description="Check for broken links",
             failure_message="Found broken links",
             expected_behavior="All links should be valid",

--- a/tests/unit/test_yaml_frontmatter_validator.py
+++ b/tests/unit/test_yaml_frontmatter_validator.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle
 from drift.validation.validators.core.format_validators import YamlFrontmatterValidator
 
@@ -42,7 +42,7 @@ This is the content of the skill.
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate skill frontmatter",
             file_path="SKILL.md",
             params={"required_fields": ["title", "description"]},
@@ -65,7 +65,7 @@ title: Test Skill
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate skill frontmatter",
             file_path="SKILL.md",
             params={"required_fields": ["title", "description", "tags"]},
@@ -89,7 +89,7 @@ This file has no frontmatter.
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter",
             file_path="README.md",
             params={"required_fields": ["title"]},
@@ -113,7 +113,7 @@ description: A test skill
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter",
             file_path="SKILL.md",
             params={"required_fields": ["title"]},
@@ -138,7 +138,7 @@ description: [unclosed array
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter",
             file_path="SKILL.md",
             params={"required_fields": ["title"]},
@@ -161,7 +161,7 @@ description: [unclosed array
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter",
             file_path="SKILL.md",
             params={"required_fields": ["title"]},
@@ -197,7 +197,7 @@ version: 1.0.0
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter schema",
             file_path="SKILL.md",
             params={"required_fields": ["title", "description"], "schema": schema},
@@ -232,7 +232,7 @@ version: invalid-version
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter schema",
             file_path="SKILL.md",
             params={"schema": schema},
@@ -247,7 +247,7 @@ version: invalid-version
     def test_file_not_found(self, validator, bundle):
         """Test error when file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Test rule",
             file_path="nonexistent.md",
             params={"required_fields": ["title"]},
@@ -262,7 +262,7 @@ version: invalid-version
     def test_missing_file_path(self, validator, bundle):
         """Test that validation passes when file_path is missing (bundle mode with empty files)."""
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Test rule",
             params={"required_fields": ["title"]},
             failure_message="Failure",
@@ -286,7 +286,7 @@ title: Test Skill
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter exists",
             file_path="SKILL.md",
             failure_message="No frontmatter",
@@ -312,7 +312,7 @@ title: Test
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Test rule",
             file_path="SKILL.md",
             params={"required_fields": ["title"]},
@@ -346,7 +346,7 @@ dependencies:
         test_file.write_text(content)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate complex frontmatter",
             file_path="SKILL.md",
             params={"required_fields": ["title", "description", "metadata", "dependencies"]},
@@ -385,7 +385,7 @@ dependencies:
         monkeypatch.setattr(builtins, "open", mock_open)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Test rule",
             file_path="SKILL.md",
             params={"required_fields": ["title"]},
@@ -433,7 +433,7 @@ version: 1.0.0
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Test rule",
             file_path="SKILL.md",
             params={"schema": schema},
@@ -473,7 +473,7 @@ tags:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter",
             file_path="SKILL.md",
             params={"schema": schema},
@@ -503,7 +503,7 @@ description: A test skill
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate frontmatter",
             file_path="SKILL.md",
             params={"schema": schema},

--- a/tests/unit/test_yaml_frontmatter_validator_bundle_mode.py
+++ b/tests/unit/test_yaml_frontmatter_validator_bundle_mode.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators.core.format_validators import YamlFrontmatterValidator
 
@@ -51,7 +51,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate agent frontmatter",
             params={"required_fields": ["name", "description", "model"]},
             failure_message="Missing required fields",
@@ -95,7 +95,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate agent frontmatter",
             params={"required_fields": ["name", "description", "model"]},
             failure_message="Missing required fields",
@@ -151,7 +151,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate agent frontmatter",
             params={"required_fields": ["name", "description", "model"]},
             failure_message="Missing required fields",
@@ -184,7 +184,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate command frontmatter",
             params={"required_fields": ["description"]},
             failure_message="Missing frontmatter",
@@ -218,7 +218,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate command frontmatter",
             params={"required_fields": ["description"]},
             failure_message="Invalid YAML",
@@ -264,7 +264,7 @@ Content
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate agent frontmatter with schema",
             params={"required_fields": ["name", "description", "model"], "schema": schema},
             failure_message="Schema validation failed",
@@ -309,7 +309,7 @@ Content
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate agent frontmatter with schema",
             params={"schema": schema},
             failure_message="Schema validation failed",
@@ -331,7 +331,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate agent frontmatter",
             params={"required_fields": ["name", "description", "model"]},
             failure_message="Missing required fields",
@@ -376,7 +376,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate command frontmatter",
             params={"required_fields": ["description"]},
             failure_message="Missing description",
@@ -410,7 +410,7 @@ Content
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate command frontmatter",
             params={"required_fields": ["description"]},
             failure_message="Missing description",
@@ -445,7 +445,7 @@ Content
 
         # Rule with file_path (legacy mode)
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_FRONTMATTER,
+            rule_type="core:yaml_frontmatter",
             description="Validate agent frontmatter",
             file_path="test.md",
             params={"required_fields": ["name", "description", "model"]},

--- a/tests/unit/test_yaml_schema_validator.py
+++ b/tests/unit/test_yaml_schema_validator.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from drift.config.models import ValidationRule, ValidationType
+from drift.config.models import ValidationRule
 from drift.core.types import DocumentBundle, DocumentFile
 from drift.validation.validators.core.format_validators import YamlSchemaValidator
 
@@ -53,7 +53,7 @@ class TestYamlSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Validate config.yaml",
             file_path="config.yaml",
             params={"schema": schema},
@@ -80,7 +80,7 @@ class TestYamlSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Validate config.yaml",
             file_path="config.yaml",
             params={"schema": schema},
@@ -107,7 +107,7 @@ class TestYamlSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Validate config.yaml",
             file_path="config.yaml",
             params={"schema": schema},
@@ -139,7 +139,7 @@ class TestYamlSchemaValidator:
         schema_file.write_text(json.dumps(schema))
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Validate data.yaml",
             file_path="data.yaml",
             params={"schema_file": "schema.json"},
@@ -156,7 +156,7 @@ class TestYamlSchemaValidator:
         data_file.write_text("key: value\n")
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Validate data.yaml",
             file_path="data.yaml",
             params={"schema_file": "nonexistent.json"},
@@ -171,7 +171,7 @@ class TestYamlSchemaValidator:
     def test_missing_file_path(self, validator, bundle):
         """Test that validation fails when file_path is missing."""
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             params={"schema": {"type": "object"}},
             failure_message="Failure",
@@ -187,7 +187,7 @@ class TestYamlSchemaValidator:
         test_file.write_text("key: value\n")
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             failure_message="Failure",
@@ -203,7 +203,7 @@ class TestYamlSchemaValidator:
         test_file.write_text("key: value\n")
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"other_key": "value"},  # Has params but no schema/schema_file
@@ -218,7 +218,7 @@ class TestYamlSchemaValidator:
     def test_file_not_found(self, validator, bundle):
         """Test error when YAML file doesn't exist."""
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="nonexistent.yaml",
             params={"schema": {"type": "object"}},
@@ -236,7 +236,7 @@ class TestYamlSchemaValidator:
         test_file.write_text("key: value\n  bad indentation:\n")
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="invalid.yaml",
             params={"schema": {"type": "object"}},
@@ -259,7 +259,7 @@ class TestYamlSchemaValidator:
         test_file.write_text("key: value\n")
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema": {"type": "object"}},
@@ -307,7 +307,7 @@ class TestYamlSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Validate nested config",
             file_path="config.yaml",
             params={"schema": schema},
@@ -343,7 +343,7 @@ class TestYamlSchemaValidator:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Validate array",
             file_path="list.yaml",
             params={"schema": schema},
@@ -386,7 +386,7 @@ class TestYamlSchemaValidator:
         schema = {"type": "object", "properties": {"name": {"type": "string"}}}
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema": schema},
@@ -426,7 +426,7 @@ class TestYamlSchemaValidator:
         schema = {"type": "object", "properties": {"name": {"type": "string"}}}
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema": schema},
@@ -467,7 +467,7 @@ class TestYamlSchemaValidator:
         monkeypatch.setattr(builtins, "open", mock_open)
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema_file": "schema.json"},
@@ -504,7 +504,7 @@ class TestYamlSchemaValidator:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema_file": "schema.json"},
@@ -545,7 +545,7 @@ required:
         )
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema_file": "schema.yaml"},
@@ -580,7 +580,7 @@ required:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema": schema},
@@ -611,7 +611,7 @@ required:
         }
 
         rule = ValidationRule(
-            rule_type=ValidationType.YAML_SCHEMA,
+            rule_type="core:yaml_schema",
             description="Test rule",
             file_path="data.yaml",
             params={"schema": schema},


### PR DESCRIPTION
## Summary

- Added plugin system for custom validators from 3rd party Python packages
- Implemented namespaced validation types (`namespace:type` format) to prevent conflicts
- Enhanced all validators with default failure messages to reduce configuration
- Migrated all built-in validators to use `core:` namespace prefix

## Test Plan

- [x] Unit tests added (6 new test files, 2,829 lines of tests)
- [x] Coverage at 97% (exceeds 90% requirement)
- [x] Manual testing with custom validator examples completed
- [x] All linters passing (flake8, black, isort, mypy)

## Changes

### Added
- `src/drift/validation/validators/base.py` - Default message system for validators
- `tests/integration/test_plugin_system.py` - Plugin integration tests
- `tests/integration/test_plugin_system_e2e.py` - End-to-end plugin tests
- `tests/unit/test_plugin_registry.py` - Registry unit tests
- `tests/unit/test_plugin_namespace_validation.py` - Namespace validation tests
- `tests/unit/test_validator_default_messages.py` - Default message tests
- `tests/unit/test_validators_default_messages_real.py` - Real validator message tests
- `docs/validators.md` - Plugin developer guide and default message documentation

### Modified
- `src/drift/validation/validators/__init__.py` - Added plugin loading and registry methods
- `src/drift/config/models.py` - Added provider field validation and namespace pattern
- `src/drift/core/analyzer.py` - Support for provider field in rule execution
- All validators in `src/drift/validation/validators/core/*` - Added validation_type and defaults
- All validators in `src/drift/validation/validators/client/*` - Added validation_type and defaults
- `.drift_rules.yaml` - Updated to use core: namespace prefix
- 50+ test files updated to use namespaced validation types

## Related Issues

Closes #35

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>