### PR TITLE
Issue #49: Add block content line count validation rule

### DIFF
--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -5,6 +5,7 @@ model: sonnet
 skills:
   - python-basics
   - testing
+  - test-strategy
 tools: Read, Write, Edit, Bash, Grep, Glob, mcp__serena, mcp__context7
 ---
 
@@ -33,6 +34,28 @@ You focus on creating comprehensive test suites for Drift, a CLI tool that analy
 - Mock AWS Bedrock API calls appropriately
 - Create reusable test fixtures
 - Ensure tests are clear and maintainable
+
+## Your Workflow
+
+When assigned to write tests:
+
+1. **Plan First (use test-strategy skill)**
+   - Identify what tests are needed from requirements
+   - Plan edge cases using equivalence partitioning and boundary analysis
+   - Design test organization and structure
+   - Determine coverage strategy
+
+2. **Implement (use testing skill)**
+   - Write pytest tests following the plan
+   - Create fixtures and mocks as needed
+   - Follow Drift's test patterns and conventions
+   - Run tests and verify they pass
+
+3. **Verify (use both skills)**
+   - Analyze coverage gaps (test-strategy)
+   - Write additional tests for uncovered behaviors (testing)
+   - Ensure 90%+ coverage achieved with meaningful tests
+   - Verify all edge cases covered
 
 ## Testing Standards
 

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -4,6 +4,7 @@ argument-hint: "[files...]"
 skills:
   - python-basics
   - code-review
+  - test-strategy
 ---
 
 Perform a thorough code review of current changes or specified files.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,7 @@
       "Skill(definition-of-done)",
       "Skill(release)",
       "Skill(doc-audit)",
+      "Skill(test-strategy)",
       "WebSearch"
     ]
   }

--- a/.claude/skills/test-strategy/SKILL.md
+++ b/.claude/skills/test-strategy/SKILL.md
@@ -1,0 +1,552 @@
+---
+name: test-strategy
+description: Expert in strategic test planning, coverage analysis, and edge case identification. Use when determining what tests to write, analyzing coverage gaps, or planning comprehensive test suites.
+skills:
+  - testing
+  - python-basics
+---
+
+# Test Strategy Skill
+
+Expert in strategic test planning for comprehensive test coverage in the Drift project.
+
+## Core Responsibilities
+
+- Identify what tests need to be written from requirements
+- Design comprehensive test coverage strategies
+- Identify edge cases and boundary conditions
+- Organize test suites for maintainability
+- Guide test pyramid balance (unit vs integration vs e2e)
+- Analyze coverage reports to find meaningful gaps
+
+## When to Use This Skill
+
+**Use test-strategy when:**
+- Planning tests for a new feature or code change
+- Analyzing why coverage is below 90%
+- Identifying missing edge cases
+- Organizing tests for a new module
+- Reviewing test suites for completeness
+
+**Use testing skill when:**
+- Writing the actual pytest code
+- Creating fixtures and mocks
+- Running tests and interpreting results
+
+---
+
+## 1. Identifying What Tests to Write
+
+### From User Stories to Test Cases
+
+**Process:**
+1. **Extract Requirements** - What should the code do?
+2. **Identify Behaviors** - What are all the possible behaviors?
+3. **Map to Test Cases** - One test per behavior
+4. **Prioritize by Risk** - Critical path first
+
+**Example: Validator Implementation**
+
+Given user story: "Create a validator that checks if code blocks exceed maximum line count"
+
+**Requirements Analysis:**
+- R1: Find code blocks in markdown files
+- R2: Count lines in each code block
+- R3: Compare against max_count parameter
+- R4: Return None if under limit
+- R5: Return failure if over limit
+- R6: Handle files without code blocks
+
+**Behavior Mapping:**
+```python
+# From R2, R3, R4, R5:
+def test_passes_when_block_under_max()
+def test_fails_when_block_exceeds_max()
+def test_passes_when_block_equals_max()  # Boundary case!
+
+# From R6:
+def test_passes_when_no_code_blocks()
+
+# Additional behaviors discovered:
+def test_handles_empty_code_block()
+def test_handles_multiple_code_blocks()
+def test_counts_only_block_content_not_fence()
+```
+
+### Test Pyramid Guidance
+
+**Drift's Test Pyramid:**
+```
+        /\        E2E (< 5%)
+       /  \       - Full CLI workflows
+      /____\      - Multi-validator scenarios
+     /      \
+    /  INTEG \    Integration (10-15%)
+   /__________\   - Multi-phase analysis
+  /            \  - Validator with DocumentBundle
+ /     UNIT     \ Unit (80-90%)
+/________________\ - Individual validators
+                   - Utility functions
+```
+
+**When to write each type:**
+
+**Unit Tests (80-90% of tests):**
+- Individual validator logic
+- Utility functions
+- Model validation
+- Parser functions
+- Format functions
+
+**Integration Tests (10-15% of tests):**
+- Validator with DocumentBundle
+- Analyzer with multiple phases
+- Config loading with file system
+- CLI with multiple validators
+
+**E2E Tests (< 5% of tests):**
+- Full `drift --no-llm` workflow
+- Complete analysis pipeline
+- Real configuration files
+
+---
+
+## 2. Getting Good Coverage
+
+### Coverage ≠ Quality
+
+**90% coverage means:**
+✅ 90% of lines are executed during tests
+❌ NOT that 90% of behaviors are tested
+
+**Good Coverage Strategy:**
+
+1. **Start with behaviors, not lines**
+   - List all expected behaviors
+   - Write tests for each behavior
+   - Check coverage to find gaps
+
+2. **Use coverage reports to identify gaps**
+   ```bash
+   pytest --cov=drift --cov-report=term-missing
+   ```
+
+   Look for:
+   - Uncovered error handling paths
+   - Untested branches (if/else)
+   - Edge cases in conditionals
+
+3. **Branch coverage over line coverage**
+   ```bash
+   pytest --cov-branch
+   ```
+
+   Ensures both paths of if/else are tested
+
+### Coverage Analysis Workflow
+
+**When coverage is below 90%:**
+
+1. Run coverage with missing lines
+2. Analyze uncovered lines (error handling? branch? edge case?)
+3. Write meaningful tests for behaviors, not just line hits
+
+**Example - Good vs Bad Coverage:**
+
+```python
+# BAD: Just hitting lines
+def test_coverage_filler():
+    validator.validate(rule, bundle)  # Just runs the code
+
+# GOOD: Testing behavior
+def test_fails_when_schema_validation_fails():
+    # Specifically tests schema validation failure path
+    invalid_rule = ValidationRule(...)
+    result = validator.validate(invalid_rule, bundle)
+    assert result is not None
+    assert "schema validation failed" in result.observed_issue
+```
+
+### Coverage Patterns from Drift
+
+**Pattern 1: Test all validator outcomes**
+```python
+def test_passes_when_valid()           # Happy path
+def test_fails_when_invalid()          # Failure path
+def test_handles_file_not_found()      # Error path
+def test_handles_missing_params()      # Configuration error
+```
+
+**Pattern 2: Test exception paths**
+```python
+def test_missing_package(monkeypatch)  # ImportError
+def test_file_read_error(monkeypatch)  # IOError
+def test_invalid_yaml(tmp_path)        # YAMLError
+```
+
+---
+
+## 3. Identifying Edge Cases
+
+### Equivalence Partitioning
+
+**Concept:** Divide input domain into classes that should behave similarly.
+
+**Example: Line count validator**
+
+Input: code block line count (integer)
+
+**Partitions:**
+1. Below minimum (if min specified): 0, min-1
+2. Valid range: min, min+1, max-1, max
+3. Above maximum: max+1, max+100
+
+**Test strategy:** Test one value from each partition + boundaries
+
+```python
+# Partition 1: No code blocks
+def test_passes_when_no_code_blocks():
+    # content with no code blocks
+
+# Partition 2: Valid range
+def test_passes_when_in_valid_range():
+    # code block with 50 lines (middle of range)
+
+# Partition 3: Above max (if max=100)
+def test_fails_when_above_maximum():
+    # code block with 150 lines
+```
+
+### Boundary Value Analysis
+
+**Critical insight:** Bugs cluster at boundaries!
+
+**For any constraint, test:**
+1. Just below boundary
+2. At boundary
+3. Just above boundary
+
+**Example from BlockLineCountValidator:**
+
+If max_count = 100:
+```python
+def test_passes_with_99_lines()   # Just below
+def test_passes_with_100_lines()  # At boundary
+def test_fails_with_101_lines()   # Just above
+```
+
+**Common boundaries in Drift:**
+- Empty collections: [], "", {}, None
+- Zero values: 0, 0.0
+- File boundaries: empty file, no code blocks
+- String boundaries: "", "a", very long string
+
+### Type-Specific Edge Cases
+
+**Strings:**
+```python
+# Empty, whitespace, special chars, very long
+"", "   ", "\n\t", "!" * 10000
+```
+
+**Lists/Arrays:**
+```python
+# Empty, single item, many items
+[], [item], [i1, i2, ...]
+```
+
+**Files:**
+```python
+# Non-existent, empty, unreadable, malformed
+Path("missing.txt"), empty_file, invalid_markdown
+```
+
+**Numbers:**
+```python
+# Zero, negative, boundary, overflow
+0, -1, MAX_COUNT, MAX_COUNT + 1
+```
+
+### Error Guessing Technique
+
+**Based on Drift patterns, common edge cases:**
+
+1. **File operations:**
+   - File doesn't exist
+   - File is empty
+   - File is unreadable (permissions)
+   - File is malformed
+
+2. **YAML/JSON parsing:**
+   - Unclosed frontmatter
+   - Invalid YAML syntax
+   - Empty frontmatter
+   - Missing required fields
+
+3. **Validation logic:**
+   - Missing required parameters
+   - Invalid parameter types
+   - Boundary conditions
+   - Resource not found
+
+4. **Bundle operations:**
+   - Empty bundle.files
+   - Missing file_path in rule
+   - all_bundles is None
+
+---
+
+## 4. Test Organization
+
+### File Naming Conventions
+
+**Drift's pattern:**
+```
+tests/
+├── unit/
+│   ├── test_<validator_name>_validator.py
+│   └── test_<module>_<feature>.py
+├── integration/
+│   └── test_<workflow>_integration.py
+└── conftest.py
+```
+
+**Examples:**
+- `test_block_line_count_validator.py`
+- `test_yaml_frontmatter_validator.py`
+- `test_analyzer_multi_phase.py`
+
+### Test Class Organization
+
+**Drift's pattern:**
+```python
+class Test<ComponentName>:
+    """Tests for <ComponentName>."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return ComponentValidator()
+
+    @pytest.fixture
+    def bundle(self, tmp_path):
+        """Create test bundle."""
+        return DocumentBundle(...)
+
+    # Happy path tests
+    def test_passes_when_valid(self, validator, bundle):
+        ...
+
+    # Failure tests
+    def test_fails_when_invalid(self, validator, bundle):
+        ...
+
+    # Edge case tests
+    def test_handles_empty_file(self, validator, bundle):
+        ...
+```
+
+### Test Method Naming
+
+**Convention:** `test_<component>_<behavior>_<condition>`
+
+**Good names:**
+```python
+def test_validator_passes_when_within_limit()
+def test_parser_raises_error_on_invalid_json()
+def test_analyzer_skips_disabled_rules()
+```
+
+**Bad names:**
+```python
+def test_validator()              # Too vague
+def test_case_1()                 # No context
+def test_this_should_work()       # Unclear
+```
+
+### Fixture Management
+
+**Fixture hierarchy in Drift:**
+
+```python
+# conftest.py - Shared across all tests
+@pytest.fixture
+def temp_dir():
+    """Temporary directory for all tests."""
+
+# test_file.py - Test-specific fixtures
+class TestValidator:
+    @pytest.fixture
+    def validator(self):
+        """Validator instance for this test class."""
+
+    @pytest.fixture
+    def bundle(self, tmp_path):
+        """Test bundle with specific setup."""
+```
+
+**Fixture composition:**
+```python
+# Build complex fixtures from simple ones
+@pytest.fixture
+def sample_drift_config(
+    sample_provider_config,
+    sample_model_config,
+    sample_learning_type
+):
+    """Compose complex config from simpler fixtures."""
+    return DriftConfig(
+        providers={"bedrock": sample_provider_config},
+        models={"haiku": sample_model_config},
+        ...
+    )
+```
+
+---
+
+## 5. Mocking Strategies
+
+### When to Mock
+
+**Mock when:**
+- Testing code that depends on external services (APIs, databases)
+- Testing code with non-deterministic behavior (time, random)
+- Testing code with slow operations (file I/O, network calls)
+- Isolating the unit under test from its dependencies
+
+**Don't mock when:**
+- Testing simple pure functions
+- Testing internal implementation details
+- Over-isolating leads to meaningless tests
+- The real dependency is fast and reliable
+
+### Choosing Your Tool
+
+**pytest monkeypatch:**
+- Simple attribute/function replacements
+- Environment variables
+- Dictionary/object modifications
+- Built-in, no extra dependencies
+
+**unittest.mock / pytest-mock:**
+- Complex mocking with call tracking
+- Need to verify how mocks are called
+- Decorator-based patching
+- More advanced features (return_value, side_effect)
+
+### Mock Verification
+
+Always verify mocks are called correctly:
+- `assert_called_once()`
+- `assert_called_with(args)`
+- `mock.call_count`
+- `mock.call_args_list`
+
+**Example from Drift:**
+
+```python
+from unittest.mock import Mock, patch
+
+@patch("drift.providers.anthropic.Anthropic", autospec=True)
+def test_token_counting(mock_anthropic):
+    """Test with autospec for type safety."""
+    # Configure mock
+    mock_client = Mock()
+    mock_client.count_tokens.return_value = 500
+    mock_anthropic.return_value = mock_client
+
+    # Test
+    result = count_tokens("test content")
+
+    # Verify
+    assert result == 500
+    mock_client.count_tokens.assert_called_once_with("test content")
+```
+
+**Common anti-patterns to avoid:**
+- Over-mocking (too many mocks = brittle tests)
+- Not using `autospec=True` (allows invalid method signatures)
+- Mocking implementation instead of interface
+- Mocks falling out of sync with reality
+
+---
+
+## Test Strategy Workflow
+
+### Planning Tests for New Feature
+
+1. **Understand the requirement**
+   - Read user story/issue
+   - Identify acceptance criteria
+   - List expected behaviors
+
+2. **Identify test types needed**
+   - Primarily unit tests?
+   - Need integration tests?
+   - Any e2e scenarios?
+
+3. **List all behaviors to test**
+   - Happy path
+   - Failure cases
+   - Edge cases
+   - Error conditions
+
+4. **Design test structure**
+   - Test class name
+   - Fixture requirements
+   - Test method names
+
+5. **Implement tests**
+   - Use testing skill for pytest details
+   - Follow Drift patterns from similar tests
+
+### Analyzing Coverage Gaps
+
+1. **Run coverage report:**
+   ```bash
+   pytest --cov=drift --cov-report=term-missing --cov-branch
+   ```
+
+2. **For each uncovered line, ask:**
+   - What behavior triggers this line?
+   - Is it an edge case I missed?
+   - Is it error handling?
+   - Is it defensive code that's OK to skip?
+
+3. **Write targeted tests:**
+   - One test per uncovered behavior
+   - Focus on meaningful coverage, not just lines
+
+4. **Verify coverage improvement:**
+   ```bash
+   pytest --cov=drift --cov-report=term
+   ```
+
+---
+
+## Resources
+
+### 📖 [Test Identification Guide](resources/test-identification.md)
+Step-by-step process for identifying what tests to write from requirements, user stories, and code changes.
+
+**Use when:** Planning tests for a new feature or analyzing existing code for missing tests.
+
+### 📖 [Coverage Strategies](resources/coverage-strategies.md)
+Techniques for achieving meaningful 90%+ coverage beyond just hitting lines, including branch coverage and gap analysis.
+
+**Use when:** Coverage is below target or you want to improve test quality.
+
+### 📖 [Edge Case Techniques](resources/edge-case-techniques.md)
+Comprehensive guide to equivalence partitioning, boundary value analysis, and error guessing with Drift-specific examples.
+
+**Use when:** Identifying what edge cases to test or reviewing test completeness.
+
+### 📖 [Test Organization Patterns](resources/test-organization.md)
+Drift's patterns for organizing tests, naming conventions, fixture management, and test data strategies.
+
+**Use when:** Setting up tests for a new module or refactoring test structure.
+
+### 📖 [Mocking Strategies](resources/mocking-strategies.md)
+Comprehensive guide to mocking in Python/pytest, including when to mock, monkeypatch vs unittest.mock, common anti-patterns, and Drift-specific patterns.
+
+**Use when:** Deciding whether to mock, choosing mocking tools, or implementing mocks for external dependencies.

--- a/.claude/skills/test-strategy/resources/coverage-strategies.md
+++ b/.claude/skills/test-strategy/resources/coverage-strategies.md
@@ -1,0 +1,671 @@
+# Coverage Strategies
+
+Techniques for achieving meaningful 90%+ coverage beyond just hitting lines.
+
+## Understanding Coverage Metrics
+
+### Line Coverage
+
+**What it measures:**
+- Percentage of code lines executed during tests
+- Default metric reported by coverage.py
+
+**What it tells you:**
+```python
+def validate(value):
+    if value > 100:      # Line executed
+        return False     # Line executed
+    return True          # Line executed
+```
+
+Line coverage = 100% if test calls `validate(50)`
+But we haven't tested the `if value > 100` branch!
+
+**Limitations:**
+- Doesn't ensure all branches tested
+- Doesn't ensure all conditions tested
+- Can miss edge cases
+- Can be gamed with superficial tests
+
+### Branch Coverage
+
+**What it measures:**
+- Percentage of code branches executed
+- Tests both True and False paths of conditionals
+
+**Example:**
+```python
+def validate(value):
+    if value > 100:      # Branch point
+        return False     # Branch 1
+    return True          # Branch 2
+```
+
+**Branch coverage requires:**
+- Test with `value > 100` (Branch 1)
+- Test with `value <= 100` (Branch 2)
+
+**How to use:**
+```bash
+pytest --cov=drift --cov-branch --cov-report=term-missing
+```
+
+**Why it's better:**
+- Ensures all decision paths tested
+- Catches untested conditions
+- More meaningful than line coverage
+
+### Path Coverage
+
+**What it measures:**
+- All possible execution paths through code
+- Most comprehensive but often impractical
+
+**Example:**
+```python
+def complex_logic(a, b):
+    if a > 0:           # Branch 1
+        if b > 0:       # Branch 2
+            return "both positive"
+        return "a positive"
+    if b > 0:           # Branch 3
+        return "b positive"
+    return "both non-positive"
+```
+
+**Paths:**
+1. a>0, b>0 → "both positive"
+2. a>0, b<=0 → "a positive"
+3. a<=0, b>0 → "b positive"
+4. a<=0, b<=0 → "both non-positive"
+
+Path coverage requires testing all 4 paths.
+
+**When to use:**
+- Critical algorithms
+- Complex business logic
+- Security-sensitive code
+
+---
+
+## Coverage Analysis Workflow
+
+### Step 1: Run Coverage Report
+
+```bash
+# Basic coverage
+pytest --cov=drift --cov-report=term-missing
+
+# With branch coverage
+pytest --cov=drift --cov-branch --cov-report=term-missing
+
+# With HTML report for detailed analysis
+pytest --cov=drift --cov-branch --cov-report=html
+```
+
+### Step 2: Interpret Results
+
+**Terminal output:**
+```
+Name                               Stmts   Miss Branch BrPart  Cover
+--------------------------------------------------------------------
+src/drift/validation/validators/
+  core/file_validators.py            156     12     42      8    89%
+```
+
+**What this means:**
+- 156 total statements
+- 12 statements not executed (shown with line numbers)
+- 42 branch points
+- 8 branches partially covered (one path tested, other not)
+- 89% overall coverage
+
+**Missing lines shown:**
+```
+src/drift/validation/validators/core/file_validators.py
+  150-155, 200-202, 220
+```
+
+### Step 3: Analyze Uncovered Lines
+
+For each uncovered line, ask:
+
+**Question 1: What behavior triggers this line?**
+```python
+# Line 150-155 uncovered
+except ImportError:
+    raise RuntimeError("tiktoken package required")
+```
+→ Behavior: Handle missing tiktoken package
+→ Test needed: Mock missing import
+
+**Question 2: Is this an edge case I missed?**
+```python
+# Line 200 uncovered
+if min_count and count < min_count:
+    return create_failure("too few")
+```
+→ Edge case: min_count validation
+→ Test needed: Test with min_count parameter
+
+**Question 3: Is this error handling?**
+```python
+# Line 220 uncovered
+except Exception as e:
+    logger.error(f"Unexpected error: {e}")
+    raise
+```
+→ Error handling: Generic exception catch
+→ Test needed: Simulate unexpected error
+
+**Question 4: Is this defensive code?**
+```python
+# Line 250 uncovered
+assert isinstance(value, int), "value must be int"
+```
+→ Defensive assertion
+→ Consider: Is this worth testing or can skip?
+
+### Step 4: Write Targeted Tests
+
+For each identified gap, write a specific test:
+
+```python
+# For line 150-155 (missing tiktoken)
+def test_raises_error_when_tiktoken_missing(monkeypatch):
+    """Test that missing tiktoken raises clear error."""
+    # Remove tiktoken from sys.modules
+    monkeypatch.setitem(sys.modules, "tiktoken", None)
+
+    with pytest.raises(RuntimeError, match="tiktoken package required"):
+        validator.count_tokens("test content")
+
+# For line 200 (min_count)
+def test_fails_when_below_min_count():
+    """Test validation fails when count below minimum."""
+    rule = ValidationRule(min_count=10, max_count=100)
+    bundle = create_bundle_with_lines(5)  # 5 < min
+
+    result = validator.validate(rule, bundle)
+
+    assert result is not None
+    assert "too few" in result.observed_issue
+```
+
+---
+
+## Common Coverage Gaps
+
+### Gap 1: Error Handling Paths
+
+**Pattern:**
+```python
+try:
+    result = risky_operation()
+except SpecificError:
+    # This line uncovered!
+    handle_error()
+```
+
+**How to test:**
+```python
+def test_handles_specific_error(monkeypatch):
+    """Test error handling for SpecificError."""
+    def mock_risky():
+        raise SpecificError("test error")
+
+    monkeypatch.setattr(module, "risky_operation", mock_risky)
+
+    # Now error handling path will be executed
+    validator.process()
+```
+
+**Drift examples:**
+```python
+def test_handles_missing_anthropic_package(monkeypatch)
+def test_handles_file_read_error(monkeypatch)
+def test_handles_yaml_parse_error(tmp_path)
+```
+
+### Gap 2: Branch Conditions
+
+**Pattern:**
+```python
+if condition_a and condition_b:
+    # Path 1
+else:
+    # Path 2 - only this tested!
+```
+
+**Missing tests:**
+- condition_a=True, condition_b=True (Path 1)
+- condition_a=True, condition_b=False (Path 2)
+- condition_a=False, condition_b=True (Path 2)
+- condition_a=False, condition_b=False (Path 2)
+
+**How to test:**
+```python
+def test_both_conditions_true()   # Path 1
+def test_first_false()             # Path 2
+def test_second_false()            # Path 2
+def test_both_false()              # Path 2
+```
+
+### Gap 3: Edge Case Logic
+
+**Pattern:**
+```python
+if value <= 0:
+    return "invalid"
+elif value < 100:
+    return "low"
+elif value < 1000:
+    return "medium"
+else:
+    return "high"
+```
+
+**Missing tests often:**
+- Boundary values: 0, 1, 99, 100, 999, 1000
+- Negative values: -1, -100
+
+**How to test:**
+```python
+@pytest.mark.parametrize("value,expected", [
+    (-1, "invalid"),      # Negative
+    (0, "invalid"),       # Boundary
+    (1, "low"),           # Boundary
+    (99, "low"),          # Boundary
+    (100, "medium"),      # Boundary
+    (999, "medium"),      # Boundary
+    (1000, "high"),       # Boundary
+])
+def test_categorization(value, expected):
+    assert categorize(value) == expected
+```
+
+### Gap 4: Configuration Variations
+
+**Pattern:**
+```python
+def process(config):
+    if config.get("optional_feature"):
+        # Feature enabled path - uncovered!
+        use_feature()
+
+    # Normal processing
+    ...
+```
+
+**Missing tests:**
+- With optional_feature=True
+- With optional_feature=False
+- With optional_feature missing
+
+**How to test:**
+```python
+def test_with_optional_feature_enabled():
+    config = {"optional_feature": True}
+    result = process(config)
+    # Assert feature was used
+
+def test_with_optional_feature_disabled():
+    config = {"optional_feature": False}
+    result = process(config)
+    # Assert feature not used
+
+def test_with_optional_feature_missing():
+    config = {}  # No optional_feature key
+    result = process(config)
+    # Assert feature not used
+```
+
+---
+
+## Meaningful vs Superficial Coverage
+
+### Bad Coverage (Line Chasing)
+
+**Anti-pattern: Just runs code**
+```python
+def test_validator():
+    """Test validator."""
+    validator = MyValidator()
+    result = validator.validate(rule, bundle)
+    # No assertions!
+```
+
+**Problems:**
+- Doesn't verify behavior
+- Would pass even if validator is broken
+- Just hits lines, doesn't test correctness
+
+### Good Coverage (Behavior Testing)
+
+**Pattern: Tests specific behavior**
+```python
+def test_fails_when_block_exceeds_max_lines():
+    """Test that validation fails when code block exceeds max_count."""
+    validator = BlockLineCountValidator()
+
+    # Create bundle with block exceeding limit
+    content = "```python\n" + "\n".join(["line"] * 150) + "\n```"
+    bundle = create_bundle(content)
+
+    # Rule with max_count = 100
+    rule = ValidationRule(max_count=100)
+
+    # Execute
+    result = validator.validate(rule, bundle)
+
+    # Verify specific behavior
+    assert result is not None, "Should fail when block exceeds limit"
+    assert result.rule_id == "block_line_count"
+    assert "exceeds maximum" in result.observed_issue.lower()
+    assert "150" in result.observed_issue  # Reports actual count
+    assert "100" in result.observed_issue  # Reports limit
+```
+
+**Why it's good:**
+- Tests specific requirement
+- Verifies correct failure
+- Checks error message quality
+- Would fail if behavior breaks
+
+### Coverage Quality Checklist
+
+For each test, verify:
+- [ ] Tests one specific behavior
+- [ ] Has clear, descriptive name
+- [ ] Includes meaningful assertions
+- [ ] Would fail if behavior breaks
+- [ ] Checks both success and failure paths
+- [ ] Verifies error messages are helpful
+
+---
+
+## Coverage Improvement Techniques
+
+### Technique 1: Parametrize for Variations
+
+**Instead of:**
+```python
+def test_with_provider_anthropic():
+    result = select_tokenizer("anthropic")
+    assert result == "anthropic_tokenizer"
+
+def test_with_provider_openai():
+    result = select_tokenizer("openai")
+    assert result == "openai_tokenizer"
+
+def test_with_provider_llama():
+    result = select_tokenizer("llama")
+    assert result == "llama_tokenizer"
+```
+
+**Use parametrize:**
+```python
+@pytest.mark.parametrize("provider,expected", [
+    ("anthropic", "anthropic_tokenizer"),
+    ("openai", "openai_tokenizer"),
+    ("llama", "llama_tokenizer"),
+    ("unknown", "default_tokenizer"),  # Edge case added easily
+])
+def test_tokenizer_selection(provider, expected):
+    result = select_tokenizer(provider)
+    assert result == expected
+```
+
+**Benefits:**
+- Less code duplication
+- Easier to add edge cases
+- Better coverage with less effort
+
+### Technique 2: Fixture Composition
+
+**Instead of:**
+```python
+def test_validator_with_complex_setup():
+    # 20 lines of setup
+    config = {...}
+    provider = Provider(config)
+    model = Model(config)
+    validator = Validator(provider, model)
+    bundle = DocumentBundle(...)
+    # ... test
+```
+
+**Use fixtures:**
+```python
+@pytest.fixture
+def validator(sample_provider, sample_model):
+    return Validator(sample_provider, sample_model)
+
+@pytest.fixture
+def bundle(tmp_path):
+    return create_test_bundle(tmp_path)
+
+def test_validator(validator, bundle):
+    # Clean, focused test
+    result = validator.validate(rule, bundle)
+    assert result is None
+```
+
+### Technique 3: Monkeypatch for Errors
+
+**Simulate errors without complex mocking:**
+```python
+def test_handles_import_error(monkeypatch):
+    """Test handling of missing optional dependency."""
+    # Make import fail
+    monkeypatch.setitem(sys.modules, "optional_package", None)
+
+    # Now this path will be covered
+    with pytest.raises(RuntimeError, match="optional_package required"):
+        validator.initialize()
+
+def test_handles_file_read_error(monkeypatch):
+    """Test handling of file read errors."""
+    def mock_read_text():
+        raise IOError("Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "permission denied" in result.observed_issue.lower()
+```
+
+### Technique 4: tmp_path for Files
+
+**Test file operations cleanly:**
+```python
+def test_validates_multiple_files(tmp_path):
+    """Test validation across multiple files."""
+    # Create test files
+    file1 = tmp_path / "file1.md"
+    file1.write_text("```python\nshort\n```")
+
+    file2 = tmp_path / "file2.md"
+    file2.write_text("```python\n" + "\n".join(["line"] * 150) + "\n```")
+
+    # Create bundle
+    bundle = create_bundle_from_dir(tmp_path)
+
+    # Validate
+    result = validator.validate(rule, bundle)
+
+    # Should fail because file2 exceeds limit
+    assert result is not None
+    assert "file2.md" in result.file_path
+```
+
+---
+
+## Case Study: 90% → 95% Coverage
+
+### Initial State (90% coverage)
+
+**Missing coverage:**
+```
+src/drift/validation/validators/core/block_validators.py
+  45-48, 67, 89-92, 110
+```
+
+### Analysis
+
+**Lines 45-48:** ImportError handling for optional package
+```python
+try:
+    from markdown_parser import extract_blocks
+except ImportError:
+    # Lines 45-48 uncovered
+    raise RuntimeError("markdown_parser required")
+```
+
+**Line 67:** min_count parameter handling
+```python
+if min_count and count < min_count:  # min_count path uncovered
+    return create_failure("too few lines")
+```
+
+**Lines 89-92:** Generic exception handling
+```python
+except Exception as e:
+    # Lines 89-92 uncovered
+    logger.error(f"Unexpected: {e}")
+    raise
+```
+
+**Line 110:** Empty code block edge case
+```python
+if len(block.lines) == 0:  # Uncovered
+    continue  # Skip empty blocks
+```
+
+### Tests Added
+
+```python
+def test_raises_error_when_parser_missing(monkeypatch):
+    """Test handling of missing markdown_parser package."""
+    monkeypatch.setitem(sys.modules, "markdown_parser", None)
+    with pytest.raises(RuntimeError, match="markdown_parser required"):
+        BlockLineCountValidator()
+
+def test_fails_when_below_min_count():
+    """Test validation fails when below minimum."""
+    rule = ValidationRule(min_count=10, max_count=100)
+    bundle = create_bundle_with_lines(5)
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "too few" in result.observed_issue
+
+def test_handles_unexpected_error(monkeypatch):
+    """Test handling of unexpected errors."""
+    def mock_extract():
+        raise RuntimeError("Unexpected!")
+    monkeypatch.setattr(validator, "_extract_blocks", mock_extract)
+    with pytest.raises(RuntimeError, match="Unexpected"):
+        validator.validate(rule, bundle)
+
+def test_skips_empty_code_blocks():
+    """Test that empty code blocks are skipped."""
+    content = "```python\n```\n```python\ncode\n```"
+    bundle = create_bundle(content)
+    result = validator.validate(rule, bundle)
+    # Should only count the non-empty block
+```
+
+### Result
+
+Coverage: 90% → 95% ✅
+
+All meaningful paths now tested.
+
+---
+
+## When to Skip Coverage
+
+### Acceptable Gaps
+
+**1. Main block:**
+```python
+if __name__ == "__main__":
+    main()
+```
+→ Skip: Entry points tested via CLI tests
+
+**2. Defensive assertions:**
+```python
+assert isinstance(value, int), "Developer error"
+```
+→ Skip: Type hints + validation prevent this
+
+**3. Logger configuration:**
+```python
+logging.basicConfig(
+    format="%(message)s",
+    level=logging.INFO
+)
+```
+→ Skip: Infrastructure, not business logic
+
+**4. Development-only code:**
+```python
+if DEBUG:
+    print(f"Debug: {state}")
+```
+→ Skip: Not production code
+
+**5. Abstract methods:**
+```python
+def validate(self):
+    raise NotImplementedError
+```
+→ Skip: Tested via implementations
+
+### How to Skip
+
+**Add pragma comment:**
+```python
+if __name__ == "__main__":  # pragma: no cover
+    main()
+```
+
+**Configure in pyproject.toml:**
+```toml
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+]
+```
+
+---
+
+## Coverage Best Practices
+
+### Do:
+- Start with behaviors, not lines
+- Use branch coverage
+- Test error paths
+- Parametrize for variations
+- Use fixtures for reusable setup
+- Focus on meaningful coverage
+
+### Don't:
+- Chase 100% coverage
+- Write tests just to hit lines
+- Skip error handling tests
+- Ignore branch coverage
+- Test implementation details
+- Skip boundary conditions
+
+### Remember:
+
+**Coverage is a tool, not a goal.**
+
+The goal is comprehensive, maintainable tests that give confidence in the code. Coverage helps find gaps, but 95% meaningful coverage is better than 100% superficial coverage.

--- a/.claude/skills/test-strategy/resources/edge-case-techniques.md
+++ b/.claude/skills/test-strategy/resources/edge-case-techniques.md
@@ -1,0 +1,799 @@
+# Edge Case Techniques
+
+Comprehensive techniques for identifying and testing edge cases.
+
+## What is an Edge Case?
+
+**Definition:** An edge case is a scenario that occurs at an extreme (edge) of operating parameters.
+
+**Examples:**
+- Empty input: `[]`, `""`, `{}`
+- Boundary values: `0`, `MAX_VALUE`, `-1`
+- Special characters: `\n`, `\t`, `None`
+- Unusual combinations: empty string in required field
+
+**Why they matter:**
+- Bugs cluster at boundaries
+- Edge cases often overlooked in normal testing
+- Can cause crashes, security issues, or incorrect behavior
+- Often discovered in production if not tested
+
+---
+
+## Equivalence Partitioning
+
+### Concept
+
+**Divide input domain into equivalence classes** - groups of inputs that should behave the same way.
+
+**Test strategy:** Test one representative from each class + all boundaries between classes.
+
+### How to Apply
+
+**Step 1: Identify input domain**
+
+Example: Block line count validator
+- Input: Number of lines in a code block
+- Range: 0 to infinity
+
+**Step 2: Divide into equivalence classes**
+
+Given max_count = 100:
+
+**Class 1:** No code blocks (special case)
+- Representative: File with no code blocks
+
+**Class 2:** Valid blocks (0 < lines <= max_count)
+- Representative: Block with 50 lines
+
+**Class 3:** Invalid blocks (lines > max_count)
+- Representative: Block with 150 lines
+
+**Step 3: Select representatives**
+
+```python
+# Class 1
+def test_passes_when_no_code_blocks():
+    content = "# Just markdown, no code"
+    bundle = create_bundle(content)
+    result = validator.validate(rule, bundle)
+    assert result is None
+
+# Class 2
+def test_passes_when_block_in_valid_range():
+    content = "```python\n" + "\n".join(["line"] * 50) + "\n```"
+    bundle = create_bundle(content)
+    result = validator.validate(rule, bundle)
+    assert result is None
+
+# Class 3
+def test_fails_when_block_exceeds_max():
+    content = "```python\n" + "\n".join(["line"] * 150) + "\n```"
+    bundle = create_bundle(content)
+    result = validator.validate(rule, bundle)
+    assert result is not None
+```
+
+### Drift Example: Token Count Validator
+
+**Input domain:** Token count (integer)
+
+**Given rule:** min_count=500, max_count=1500
+
+**Equivalence classes:**
+
+1. Below minimum: count < 500
+2. Valid range: 500 <= count <= 1500
+3. Above maximum: count > 1500
+
+**Tests:**
+```python
+def test_fails_when_below_minimum():
+    """Test with 300 tokens (Class 1 representative)."""
+    content = "short text"  # ~300 tokens
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "below minimum" in result.observed_issue
+
+def test_passes_when_in_valid_range():
+    """Test with 1000 tokens (Class 2 representative)."""
+    content = generate_text(1000)  # Exactly 1000 tokens
+    result = validator.validate(rule, bundle)
+    assert result is None
+
+def test_fails_when_above_maximum():
+    """Test with 2000 tokens (Class 3 representative)."""
+    content = generate_text(2000)  # Exactly 2000 tokens
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "exceeds maximum" in result.observed_issue
+```
+
+### Multi-Dimensional Partitioning
+
+**Example: File validation with multiple parameters**
+
+**Parameters:**
+- file_exists: True/False
+- file_readable: True/False
+- file_valid: True/False
+
+**Equivalence classes:**
+```
+1. exists=False, readable=N/A, valid=N/A → File not found error
+2. exists=True, readable=False, valid=N/A → Permission error
+3. exists=True, readable=True, valid=False → Validation error
+4. exists=True, readable=True, valid=True → Success
+```
+
+**Tests:**
+```python
+def test_fails_when_file_not_found():
+    """Class 1: File doesn't exist."""
+    result = validator.validate_file("missing.md")
+    assert "not found" in result.error
+
+def test_fails_when_file_unreadable(tmp_path):
+    """Class 2: File exists but can't be read."""
+    file = tmp_path / "unreadable.md"
+    file.write_text("content")
+    file.chmod(0o000)  # No permissions
+    result = validator.validate_file(str(file))
+    assert "permission" in result.error.lower()
+
+def test_fails_when_file_invalid(tmp_path):
+    """Class 3: File readable but invalid content."""
+    file = tmp_path / "invalid.md"
+    file.write_text("---\ninvalid: yaml: content\n---")
+    result = validator.validate_file(str(file))
+    assert "invalid" in result.error.lower()
+
+def test_passes_when_file_valid(tmp_path):
+    """Class 4: Everything valid."""
+    file = tmp_path / "valid.md"
+    file.write_text("---\ntitle: Test\n---\nContent")
+    result = validator.validate_file(str(file))
+    assert result.success
+```
+
+---
+
+## Boundary Value Analysis
+
+### The Boundary Bug Principle
+
+**Research shows:** 70-80% of defects occur at boundaries!
+
+**Why?**
+- Off-by-one errors
+- Incorrect comparison operators (`<` vs `<=`)
+- Integer overflow
+- Edge of valid ranges
+
+### Standard Boundaries to Test
+
+For any range [min, max]:
+
+**Always test:**
+- `min - 1` (just below)
+- `min` (at lower boundary)
+- `min + 1` (just above lower)
+- `max - 1` (just below upper)
+- `max` (at upper boundary)
+- `max + 1` (just above)
+
+**Additionally:**
+- `0` (if applicable)
+- `1` (smallest positive)
+- `-1` (if negative values possible)
+- Empty/null (if applicable)
+
+### Drift-Specific Boundaries
+
+#### File Operations
+
+**Code block line count:**
+```python
+# If max_count = 100
+def test_passes_with_99_lines():
+    """Just below boundary."""
+    content = create_code_block(99)
+    assert validator.validate(rule, bundle) is None
+
+def test_passes_with_100_lines():
+    """At boundary - critical test!"""
+    content = create_code_block(100)
+    assert validator.validate(rule, bundle) is None
+
+def test_fails_with_101_lines():
+    """Just above boundary."""
+    content = create_code_block(101)
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "exceeds" in result.observed_issue
+```
+
+**Empty file boundary:**
+```python
+def test_handles_empty_file(tmp_path):
+    """Boundary: 0 bytes."""
+    file = tmp_path / "empty.md"
+    file.write_text("")
+    bundle = create_bundle_from_file(file)
+    result = validator.validate(rule, bundle)
+    # Should handle gracefully, not crash
+
+def test_handles_single_line_file(tmp_path):
+    """Boundary: 1 line."""
+    file = tmp_path / "single.md"
+    file.write_text("one line")
+    bundle = create_bundle_from_file(file)
+    result = validator.validate(rule, bundle)
+    # Should process normally
+```
+
+#### Numeric Constraints
+
+**Token count limits:**
+```python
+# If max_count = 1500
+def test_passes_with_1499_tokens():
+    """Just below maximum."""
+    content = generate_text_with_tokens(1499)
+    assert validator.validate(rule, bundle) is None
+
+def test_passes_with_1500_tokens():
+    """At maximum boundary."""
+    content = generate_text_with_tokens(1500)
+    assert validator.validate(rule, bundle) is None
+
+def test_fails_with_1501_tokens():
+    """Just above maximum."""
+    content = generate_text_with_tokens(1501)
+    result = validator.validate(rule, bundle)
+    assert result is not None
+```
+
+**Zero boundary:**
+```python
+def test_handles_zero_tokens():
+    """Boundary: empty content."""
+    content = ""
+    result = validator.validate(rule, bundle)
+    # How should this be handled?
+
+def test_handles_one_token():
+    """Boundary: minimal content."""
+    content = "word"
+    result = validator.validate(rule, bundle)
+    # Should process normally
+```
+
+#### String Lengths
+
+**Validation message length:**
+```python
+def test_handles_empty_string():
+    """Boundary: zero length."""
+    result = validator.process("")
+    assert result is not None
+
+def test_handles_single_char():
+    """Boundary: length 1."""
+    result = validator.process("a")
+    assert result is not None
+
+def test_handles_very_long_string():
+    """Boundary: max length."""
+    content = "a" * 10000
+    result = validator.process(content)
+    # Should handle or reject gracefully
+```
+
+---
+
+## Type-Specific Edge Cases
+
+### Strings
+
+**Edge cases:**
+```python
+# Empty
+""
+
+# Whitespace only
+"   "
+"   \t\n   "
+
+# Special characters
+"\n\n\n"
+"\t\t\t"
+"!@#$%^&*()"
+
+# Unicode
+"测试"
+"🚀"
+
+# Very long
+"a" * 100000
+
+# Quotes and escaping
+"string with \"quotes\""
+"string with 'quotes'"
+"string with \\backslash"
+```
+
+**Drift example: Frontmatter parsing**
+```python
+def test_handles_empty_frontmatter():
+    """Edge: Empty frontmatter block."""
+    content = "---\n---\nContent"
+    result = parse_frontmatter(content)
+    assert result == {}
+
+def test_handles_whitespace_only_frontmatter():
+    """Edge: Only whitespace in frontmatter."""
+    content = "---\n   \n---\nContent"
+    result = parse_frontmatter(content)
+    assert result == {}
+
+def test_handles_unicode_in_frontmatter():
+    """Edge: Unicode characters."""
+    content = "---\ntitle: 测试\n---\nContent"
+    result = parse_frontmatter(content)
+    assert result["title"] == "测试"
+
+def test_handles_special_chars_in_values():
+    """Edge: Special YAML characters."""
+    content = '---\ntitle: "Value: with colons"\n---'
+    result = parse_frontmatter(content)
+    assert result["title"] == "Value: with colons"
+```
+
+### Collections (Lists/Dicts)
+
+**Lists edge cases:**
+```python
+# Empty
+[]
+
+# Single element
+[x]
+
+# Duplicates
+[x, x, x]
+
+# None values
+[None, None]
+[x, None, y]
+
+# Mixed types (if applicable)
+[1, "string", None]
+```
+
+**Drift example: Bundle files**
+```python
+def test_handles_empty_files_list():
+    """Edge: No files in bundle."""
+    bundle = DocumentBundle(
+        bundle_id="test",
+        bundle_type="skill",
+        files=[],  # Empty!
+        project_path="/test"
+    )
+    result = validator.validate(rule, bundle)
+    # Should handle gracefully
+
+def test_handles_single_file():
+    """Edge: One file only."""
+    bundle = create_bundle_with_files(1)
+    result = validator.validate(rule, bundle)
+    assert result is not None or result is None  # Valid case
+
+def test_handles_duplicate_file_paths():
+    """Edge: Same file path twice."""
+    file = DocumentFile(relative_path="test.md", ...)
+    bundle = DocumentBundle(files=[file, file])
+    result = validator.validate(rule, bundle)
+    # How should this be handled?
+```
+
+**Dictionaries edge cases:**
+```python
+# Empty
+{}
+
+# Missing required keys
+{"key1": "value"}  # When key2 required
+
+# Extra unexpected keys
+{"key1": "v1", "unexpected": "v2"}
+
+# None values
+{"key": None}
+
+# Nested empty
+{"key": {}}
+{"key": []}
+```
+
+**Drift example: Rule parameters**
+```python
+def test_handles_missing_required_param():
+    """Edge: Required parameter not provided."""
+    rule = ValidationRule()  # No max_count!
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "missing" in result.observed_issue.lower()
+
+def test_handles_none_parameter():
+    """Edge: Parameter explicitly None."""
+    rule = ValidationRule(max_count=None)
+    result = validator.validate(rule, bundle)
+    assert result is not None
+
+def test_handles_extra_parameters():
+    """Edge: Unexpected parameters provided."""
+    rule = ValidationRule(
+        max_count=100,
+        unexpected_param="value"
+    )
+    # Should ignore extra params or raise error?
+```
+
+### Files
+
+**File edge cases:**
+```python
+# Non-existent
+Path("missing.txt")
+
+# Empty file (0 bytes)
+Path("empty.txt")  # file.stat().st_size == 0
+
+# Unreadable (permissions)
+Path("no_perms.txt")  # chmod 000
+
+# Malformed content
+Path("invalid.yaml")  # Contains: "key: [unclosed"
+
+# Very large file
+Path("huge.txt")  # 1GB+
+
+# Binary file (when expecting text)
+Path("image.png")
+
+# Symlink (if relevant)
+Path("link.txt")  # -> real_file.txt
+```
+
+**Drift example: File validation**
+```python
+def test_handles_file_not_found():
+    """Edge: File doesn't exist."""
+    rule = ValidationRule(file_path="missing.md")
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "not found" in result.observed_issue
+
+def test_handles_empty_file(tmp_path):
+    """Edge: Zero-byte file."""
+    file = tmp_path / "empty.md"
+    file.write_text("")
+    bundle = create_bundle_from_file(file)
+    result = validator.validate(rule, bundle)
+    # Should handle gracefully
+
+def test_handles_unreadable_file(tmp_path):
+    """Edge: File exists but can't be read."""
+    file = tmp_path / "secret.md"
+    file.write_text("content")
+    file.chmod(0o000)
+    # Simulate permission error
+    result = validator.validate_file(str(file))
+    assert "permission" in str(result).lower()
+
+def test_handles_malformed_file(tmp_path):
+    """Edge: File with invalid format."""
+    file = tmp_path / "bad.yaml"
+    file.write_text("---\nkey: [unclosed\n---")
+    result = validator.validate_file(str(file))
+    assert result is not None
+```
+
+### Numbers
+
+**Numeric edge cases:**
+```python
+# Zero
+0
+0.0
+
+# Negative
+-1
+-100
+
+# Boundary
+MAX_INT
+MIN_INT
+
+# Overflow
+MAX_INT + 1
+
+# Precision (floats)
+0.1 + 0.2  # != 0.3
+
+# Special values (if applicable)
+float('inf')
+float('-inf')
+float('nan')
+```
+
+**Drift example: Count validation**
+```python
+def test_handles_zero_count():
+    """Edge: Zero value."""
+    rule = ValidationRule(max_count=0)
+    result = validator.validate(rule, bundle)
+    # Should this be valid or error?
+
+def test_handles_negative_count():
+    """Edge: Negative value."""
+    rule = ValidationRule(max_count=-1)
+    result = validator.validate(rule, bundle)
+    assert result is not None
+    assert "positive" in result.observed_issue
+
+def test_handles_very_large_count():
+    """Edge: Maximum integer."""
+    rule = ValidationRule(max_count=sys.maxsize)
+    result = validator.validate(rule, bundle)
+    # Should handle without overflow
+```
+
+---
+
+## Error Guessing Technique
+
+### Based on Experience
+
+**Common failure patterns in Python:**
+
+1. **Import errors** - Missing optional dependencies
+2. **File operations** - Permissions, missing files, corruption
+3. **Parsing** - Malformed JSON/YAML, encoding issues
+4. **Type errors** - None when object expected, wrong type
+5. **Index errors** - Empty lists, out of bounds access
+6. **Key errors** - Missing dictionary keys
+7. **Encoding errors** - Unicode, special characters
+
+### Based on Code Review
+
+**When reviewing code, look for:**
+
+**Pattern 1: File operations without error handling**
+```python
+# Risky code
+content = Path(file_path).read_text()
+```
+
+**Edge cases to test:**
+```python
+def test_handles_file_not_found()
+def test_handles_permission_error()
+def test_handles_encoding_error()
+```
+
+**Pattern 2: Dictionary access without .get()**
+```python
+# Risky code
+value = config["optional_key"]
+```
+
+**Edge cases to test:**
+```python
+def test_handles_missing_key()
+def test_handles_none_value()
+```
+
+**Pattern 3: List access without bounds check**
+```python
+# Risky code
+first_item = items[0]
+```
+
+**Edge cases to test:**
+```python
+def test_handles_empty_list()
+def test_handles_single_item_list()
+```
+
+**Pattern 4: External API calls without error handling**
+```python
+# Risky code
+response = api.call_llm(prompt)
+```
+
+**Edge cases to test:**
+```python
+def test_handles_api_timeout()
+def test_handles_api_rate_limit()
+def test_handles_invalid_response()
+```
+
+### Drift-Specific Error Patterns
+
+#### Pattern 1: Package Availability
+
+**Code pattern:**
+```python
+try:
+    import optional_package
+except ImportError:
+    raise RuntimeError("optional_package required")
+```
+
+**Tests needed:**
+```python
+def test_raises_error_when_package_missing(monkeypatch):
+    """Test handling of missing optional dependency."""
+    monkeypatch.setitem(sys.modules, "optional_package", None)
+
+    with pytest.raises(RuntimeError, match="optional_package required"):
+        validator = MyValidator()
+```
+
+**Drift examples:**
+```python
+def test_anthropic_missing_package(monkeypatch)
+def test_tiktoken_missing_package(monkeypatch)
+def test_pyyaml_missing_package(monkeypatch)
+```
+
+#### Pattern 2: YAML/Frontmatter Parsing
+
+**Common issues:**
+```python
+# Unclosed frontmatter
+"---\ntitle: Test\n"
+
+# Invalid YAML syntax
+"---\nkey: [unclosed\n---"
+
+# Empty frontmatter
+"---\n---\n"
+
+# Missing frontmatter
+"No frontmatter here"
+```
+
+**Tests needed:**
+```python
+def test_handles_unclosed_frontmatter()
+def test_handles_invalid_yaml_syntax()
+def test_handles_empty_frontmatter()
+def test_handles_missing_frontmatter()
+```
+
+#### Pattern 3: Validation Logic
+
+**Common issues:**
+```python
+# Missing required parameters
+rule = ValidationRule()  # No max_count!
+
+# Invalid parameter types
+rule = ValidationRule(max_count="not a number")
+
+# all_bundles is None (when needed)
+validator.validate(rule, bundle, all_bundles=None)
+```
+
+**Tests needed:**
+```python
+def test_fails_when_missing_required_param()
+def test_fails_when_invalid_param_type()
+def test_handles_none_all_bundles()
+```
+
+#### Pattern 4: Circular Dependencies
+
+**Special edge case for graph algorithms:**
+```python
+# Self-loop
+skill_a depends on skill_a
+
+# Two-node cycle
+skill_a depends on skill_b
+skill_b depends on skill_a
+
+# Multi-node cycle
+skill_a → skill_b → skill_c → skill_d → skill_a
+```
+
+**Tests needed:**
+```python
+def test_detects_self_loop()
+def test_detects_two_node_cycle()
+def test_detects_multi_node_cycle()
+def test_passes_with_no_cycles()
+```
+
+---
+
+## Edge Case Checklist
+
+For any new code, verify you've tested:
+
+### Input Validation
+- [ ] Empty/null/None inputs
+- [ ] Zero values
+- [ ] Negative values
+- [ ] Boundary values (min, max)
+- [ ] Just above/below boundaries
+- [ ] Invalid types
+- [ ] Missing required parameters
+
+### Collections
+- [ ] Empty collections ([], {}, "")
+- [ ] Single-element collections
+- [ ] Duplicate elements
+- [ ] None values in collections
+- [ ] Missing dictionary keys
+
+### File Operations
+- [ ] File doesn't exist
+- [ ] File is empty
+- [ ] File is unreadable (permissions)
+- [ ] File has invalid content
+- [ ] Very large files
+
+### String Operations
+- [ ] Empty string
+- [ ] Whitespace-only string
+- [ ] Special characters
+- [ ] Unicode characters
+- [ ] Very long strings
+
+### Error Handling
+- [ ] Missing optional dependencies
+- [ ] API/network errors
+- [ ] Parsing errors
+- [ ] Type errors
+- [ ] Permission errors
+
+### Drift-Specific
+- [ ] Empty bundle.files
+- [ ] Missing frontmatter
+- [ ] Invalid YAML
+- [ ] Circular dependencies
+- [ ] all_bundles is None
+
+---
+
+## Common Edge Case Smells
+
+**Warning signs you've missed edge cases:**
+
+1. **No tests for empty inputs**
+   - Missing tests for [], {}, "", None
+
+2. **No tests for None values**
+   - Parameters, return values, collection elements
+
+3. **No tests for file errors**
+   - Missing file, permission denied, malformed
+
+4. **No tests for import errors**
+   - Missing optional dependencies
+
+5. **Only happy path tested**
+   - No failure scenarios, no error cases
+
+6. **No boundary tests**
+   - Missing min-1, min, min+1, max-1, max, max+1
+
+7. **No tests for special values**
+   - Zero, negative, empty string, etc.
+
+**If you see these smells, add edge case tests!**

--- a/.claude/skills/test-strategy/resources/mocking-strategies.md
+++ b/.claude/skills/test-strategy/resources/mocking-strategies.md
@@ -1,0 +1,860 @@
+# Mocking Strategies
+
+Strategic guidance on when, why, and how to mock in Python tests.
+
+## When to Mock vs Test Real
+
+### Decision Framework
+
+**Mock when testing code that:**
+- Depends on external services (APIs, databases, cloud services)
+- Has non-deterministic behavior (current time, random values)
+- Involves slow operations (network calls, file I/O, large computations)
+- Requires isolating the unit under test from its dependencies
+- Interacts with paid services (avoid costs during testing)
+- Has side effects you want to prevent (sending emails, writing to production DB)
+
+**Test with real dependencies when:**
+- Testing simple pure functions with no external dependencies
+- The real dependency is fast, reliable, and deterministic
+- Testing integration between components (integration tests)
+- Over-isolating would make tests meaningless
+- The dependency is part of what you're testing
+
+### Cost/Benefit Analysis
+
+**Benefits of Mocking:**
+- ✅ Tests run faster (no network/disk I/O)
+- ✅ Tests are more reliable (no external service failures)
+- ✅ Can test error scenarios easily (simulate failures)
+- ✅ No setup/teardown of external services needed
+- ✅ Tests can run offline
+
+**Costs of Mocking:**
+- ❌ Mocks can fall out of sync with real implementations
+- ❌ Over-mocking leads to brittle tests
+- ❌ Tests may pass even when code is broken
+- ❌ More code to maintain (mock setup)
+- ❌ Can miss integration issues
+
+**Rule of thumb:** Mock at system boundaries, test real internally.
+
+### Testing at Boundaries
+
+**System Boundary Pattern:**
+
+```python
+# Your code structure
+Application Code
+├── Business Logic (test with real)
+│   ├── Validators
+│   ├── Parsers
+│   └── Analyzers
+└── External Adapters (MOCK HERE)
+    ├── API Clients
+    ├── Database Access
+    └── File System
+```
+
+**Good:**
+```python
+def test_validates_user_data():
+    """Test validation logic with real validator."""
+    validator = UserValidator()  # Real
+    result = validator.validate(user_data)  # Real
+    assert result.is_valid
+
+def test_calls_api_correctly(monkeypatch):
+    """Test API interaction with mocked client."""
+    mock_client = Mock()  # Mock at boundary
+    mock_client.create_user.return_value = {"id": 123}
+
+    service = UserService(mock_client)
+    result = service.create_user(user_data)
+
+    mock_client.create_user.assert_called_once()
+```
+
+**Bad:**
+```python
+def test_validates_user_data(monkeypatch):
+    """Over-mocking internal logic."""
+    mock_validator = Mock()  # DON'T mock your own code!
+    mock_validator.validate.return_value = True
+
+    # This test is meaningless
+    result = mock_validator.validate(user_data)
+    assert result is True  # Of course it is!
+```
+
+---
+
+## Pytest Monkeypatch vs unittest.mock
+
+### Feature Comparison
+
+| Feature | pytest monkeypatch | unittest.mock |
+|---------|-------------------|---------------|
+| **Automatic cleanup** | ✅ Yes | ✅ Yes (with patch context) |
+| **Call tracking** | ❌ No | ✅ Yes |
+| **Return value control** | ⚠️ Manual | ✅ `return_value` |
+| **Side effects** | ⚠️ Manual | ✅ `side_effect` |
+| **Decorators** | ❌ No | ✅ `@patch` |
+| **Method signature validation** | ❌ No | ✅ `autospec=True` |
+| **Simple patching** | ✅ Excellent | ⚠️ More verbose |
+| **Environment variables** | ✅ Built-in | ⚠️ Manual |
+| **Dictionary patching** | ✅ Built-in | ⚠️ Manual |
+
+### When to Use Each
+
+**Use pytest monkeypatch when:**
+- Simple attribute or function replacement
+- Patching environment variables
+- Modifying dictionaries (like `sys.modules`)
+- One-line replacements
+- No need for call verification
+
+**Use unittest.mock when:**
+- Need to verify how mocks are called
+- Complex mocking scenarios with multiple returns
+- Want to use decorators for cleaner tests
+- Need `return_value` or `side_effect`
+- Testing call sequences or arguments
+
+### Drift Examples of Both
+
+**Monkeypatch Example: Missing Package**
+
+```python
+def test_anthropic_package_missing(monkeypatch):
+    """Test handling of missing anthropic package using monkeypatch."""
+    # Simple replacement in sys.modules
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+
+    with pytest.raises(RuntimeError, match="anthropic package required"):
+        provider = AnthropicProvider()
+```
+
+**Mock Example: API Call Tracking**
+
+```python
+from unittest.mock import Mock, patch
+
+@patch("drift.providers.anthropic.Anthropic", autospec=True)
+def test_counts_tokens_correctly(mock_anthropic):
+    """Test token counting with mock to verify calls."""
+    # Setup mock behavior
+    mock_client = Mock()
+    mock_client.count_tokens.return_value = 500
+    mock_anthropic.return_value = mock_client
+
+    # Execute
+    provider = AnthropicProvider()
+    result = provider.count_tokens("test content")
+
+    # Verify behavior
+    assert result == 500
+    mock_client.count_tokens.assert_called_once_with("test content")
+```
+
+---
+
+## Mocking Strategies
+
+### External APIs
+
+**Pattern: Mock the client, not the library**
+
+```python
+from unittest.mock import Mock, patch
+
+@patch("drift.providers.bedrock.boto3.client", autospec=True)
+def test_bedrock_api_call(mock_boto_client):
+    """Test AWS Bedrock API interaction."""
+    # Setup mock client
+    mock_bedrock = Mock()
+    mock_bedrock.invoke_model.return_value = {
+        "body": json.dumps({"completion": "test response"})
+    }
+    mock_boto_client.return_value = mock_bedrock
+
+    # Test
+    provider = BedrockProvider()
+    result = provider.generate("test prompt")
+
+    # Verify
+    assert "test response" in result
+    mock_bedrock.invoke_model.assert_called_once()
+```
+
+**Drift Example: Mock Provider Pattern**
+
+From `tests/mock_provider.py`:
+
+```python
+class MockProvider(Provider):
+    """Reusable mock provider for LLM testing."""
+
+    def __init__(self, provider_config=None, model_config=None):
+        self.call_count = 0
+        self.calls = []
+        self.response = "[]"
+
+    def set_response(self, response: str):
+        """Configure what the mock returns."""
+        self.response = response
+
+    def generate(self, prompt: str) -> str:
+        """Track calls and return configured response."""
+        self.call_count += 1
+        self.calls.append(prompt)
+        return self.response
+
+    def reset(self):
+        """Reset call tracking."""
+        self.call_count = 0
+        self.calls = []
+
+# Usage in tests
+def test_with_mock_provider():
+    provider = MockProvider()
+    provider.set_response('[{"type": "drift", "message": "test"}]')
+
+    result = analyze_with_provider(provider, conversation)
+
+    assert provider.call_count == 1
+    assert "drift" in result
+```
+
+### File System Operations
+
+**Strategy: Use tmp_path for real files, monkeypatch for errors**
+
+```python
+# Good: Use tmp_path for real file testing
+def test_reads_config_file(tmp_path):
+    """Test reading real file with tmp_path."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("provider: bedrock")
+
+    config = load_config(config_file)
+    assert config.provider == "bedrock"
+
+# Good: Use monkeypatch to simulate errors
+def test_handles_file_read_error(monkeypatch):
+    """Test handling of file read errors."""
+    def mock_read_text():
+        raise IOError("Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+
+    with pytest.raises(IOError, match="Permission denied"):
+        load_config("config.yaml")
+```
+
+### Import Mocking
+
+**Pattern: Use monkeypatch.setitem for sys.modules**
+
+```python
+import sys
+
+def test_optional_package_missing(monkeypatch):
+    """Test handling of missing optional dependency."""
+    # Make import fail
+    monkeypatch.setitem(sys.modules, "tiktoken", None)
+
+    # This will trigger ImportError handling
+    with pytest.raises(RuntimeError, match="tiktoken package required"):
+        tokenizer = create_tokenizer("openai")
+
+def test_optional_package_present():
+    """Test with package present (no mocking)."""
+    # Test with real package if available
+    try:
+        tokenizer = create_tokenizer("openai")
+        assert tokenizer is not None
+    except ImportError:
+        pytest.skip("tiktoken not installed")
+```
+
+### Time and Randomness
+
+**Pattern: Mock time-dependent functions**
+
+```python
+from unittest.mock import patch
+import time
+
+@patch("time.time")
+def test_rate_limiting(mock_time):
+    """Test rate limiting with mocked time."""
+    # Control time progression
+    mock_time.side_effect = [0, 0.5, 1.0, 1.5]
+
+    limiter = RateLimiter(calls_per_second=1)
+
+    assert limiter.allow()  # t=0
+    assert limiter.allow()  # t=0.5
+    assert not limiter.allow()  # t=1.0 (too fast)
+    assert limiter.allow()  # t=1.5
+
+@patch("random.random")
+def test_sampling(mock_random):
+    """Test random sampling with controlled values."""
+    mock_random.side_effect = [0.1, 0.5, 0.9]
+
+    samples = [sample_with_probability(0.5) for _ in range(3)]
+
+    assert samples == [True, True, False]  # 0.1 < 0.5, 0.5 == 0.5, 0.9 > 0.5
+```
+
+---
+
+## Mock Verification
+
+### Call Tracking
+
+**Basic verification:**
+
+```python
+from unittest.mock import Mock
+
+def test_calls_method_once():
+    """Test that method is called exactly once."""
+    mock = Mock()
+
+    process_data(mock)
+
+    mock.process.assert_called_once()
+
+def test_calls_with_correct_args():
+    """Test that method is called with specific arguments."""
+    mock = Mock()
+
+    process_data(mock, "test", count=5)
+
+    mock.process.assert_called_once_with("test", count=5)
+```
+
+### Argument Verification
+
+**Complex argument checking:**
+
+```python
+from unittest.mock import Mock, call, ANY
+
+def test_multiple_calls():
+    """Test sequence of calls."""
+    mock = Mock()
+
+    service = DataService(mock)
+    service.process_batch(["a", "b", "c"])
+
+    # Verify call sequence
+    mock.save.assert_has_calls([
+        call("a"),
+        call("b"),
+        call("c"),
+    ])
+
+def test_with_any_matcher():
+    """Test with partial argument matching."""
+    mock = Mock()
+
+    service.send_notification(user_id=123, timestamp=ANY)
+
+    mock.send.assert_called_with(user_id=123, timestamp=ANY)
+```
+
+### Call Count Assertions
+
+```python
+def test_retries_on_failure():
+    """Test retry logic."""
+    mock = Mock()
+    mock.send.side_effect = [
+        Exception("Fail"),
+        Exception("Fail"),
+        {"status": "success"}
+    ]
+
+    service = RetryService(mock, max_retries=3)
+    result = service.send_with_retry("data")
+
+    assert result["status"] == "success"
+    assert mock.send.call_count == 3  # Failed twice, succeeded third
+```
+
+### Mock Reset Strategies
+
+```python
+from unittest.mock import Mock
+
+class TestDataProcessor:
+    @pytest.fixture
+    def mock_client(self):
+        """Shared mock that resets between tests."""
+        mock = Mock()
+        yield mock
+        mock.reset_mock()  # Reset for next test
+
+    def test_first_scenario(self, mock_client):
+        """First test."""
+        processor = DataProcessor(mock_client)
+        processor.process("data1")
+
+        mock_client.send.assert_called_once()
+
+    def test_second_scenario(self, mock_client):
+        """Second test with fresh mock."""
+        processor = DataProcessor(mock_client)
+        processor.process("data2")
+
+        # Mock was reset, so count is 1, not 2
+        mock_client.send.assert_called_once()
+```
+
+---
+
+## Common Anti-Patterns
+
+### 1. Over-Mocking
+
+**Anti-pattern:**
+```python
+def test_validate_user_with_too_many_mocks(monkeypatch):
+    """BAD: Mocking everything."""
+    mock_parser = Mock()
+    mock_validator = Mock()
+    mock_formatter = Mock()
+    mock_logger = Mock()
+
+    # Test becomes meaningless
+    result = process_user(
+        data,
+        parser=mock_parser,
+        validator=mock_validator,
+        formatter=mock_formatter,
+        logger=mock_logger
+    )
+```
+
+**Better:**
+```python
+def test_validate_user(monkeypatch):
+    """GOOD: Only mock external dependency."""
+    mock_api_client = Mock()  # Only mock the API
+    mock_api_client.fetch_user.return_value = user_data
+
+    # Test real validation logic
+    validator = UserValidator(api_client=mock_api_client)
+    result = validator.validate(user_id=123)
+
+    assert result.is_valid
+```
+
+### 2. Not Using autospec
+
+**Anti-pattern:**
+```python
+@patch("mymodule.SomeClass")  # No autospec!
+def test_without_autospec(mock_class):
+    """BAD: Can call methods that don't exist."""
+    mock = Mock()
+    mock.nonexistent_method.return_value = "works"  # Silently passes!
+    mock_class.return_value = mock
+
+    # Test passes even though method doesn't exist
+    result = use_some_class()
+    assert result == "works"
+```
+
+**Better:**
+```python
+@patch("mymodule.SomeClass", autospec=True)  # With autospec!
+def test_with_autospec(mock_class):
+    """GOOD: Validates method signatures."""
+    mock = Mock(spec=SomeClass)
+    # mock.nonexistent_method()  # Would raise AttributeError!
+    mock.real_method.return_value = "works"
+    mock_class.return_value = mock
+
+    result = use_some_class()
+    assert result == "works"
+```
+
+### 3. Mocking Implementation Instead of Interface
+
+**Anti-pattern:**
+```python
+def test_mocks_private_method():
+    """BAD: Mocking internal implementation."""
+    service = UserService()
+
+    # Mocking private method couples test to implementation
+    service._internal_validation = Mock(return_value=True)
+
+    result = service.create_user(user_data)
+    assert result.success
+```
+
+**Better:**
+```python
+def test_mocks_external_dependency():
+    """GOOD: Mock external dependency, test public interface."""
+    mock_api = Mock()
+    mock_api.validate_email.return_value = True
+
+    service = UserService(email_validator=mock_api)
+    result = service.create_user(user_data)
+
+    assert result.success
+    mock_api.validate_email.assert_called_once()
+```
+
+### 4. Mocks Falling Out of Sync
+
+**Problem:**
+```python
+# Real API changed signature
+class RealAPI:
+    def send(self, data, timeout=30, retry=True):  # Added timeout, retry
+        ...
+
+# Mock hasn't been updated
+def test_with_outdated_mock():
+    """Test uses old signature."""
+    mock = Mock()
+    mock.send.return_value = "success"
+
+    # This passes but doesn't match real API!
+    result = service.send("data")  # Missing timeout, retry
+```
+
+**Solution: Use autospec**
+```python
+@patch("mymodule.RealAPI", autospec=True)
+def test_with_autospec(mock_api):
+    """autospec ensures mock matches real signature."""
+    mock_instance = Mock(spec=RealAPI)
+    mock_instance.send.return_value = "success"
+    mock_api.return_value = mock_instance
+
+    # Will fail if signature doesn't match
+    service = MyService(mock_instance)
+    result = service.send_data("data")
+```
+
+### 5. Brittle Tests from Tight Coupling
+
+**Anti-pattern:**
+```python
+def test_tightly_coupled_to_implementation():
+    """BAD: Test knows too much about implementation."""
+    mock = Mock()
+
+    service = DataService(mock)
+    service.process("data")
+
+    # Coupled to exact implementation details
+    mock.transform.assert_called_once()
+    mock.validate.assert_called_once()
+    mock.save.assert_called_once()
+    # If implementation changes order, test breaks
+```
+
+**Better:**
+```python
+def test_focuses_on_behavior():
+    """GOOD: Test focuses on behavior, not implementation."""
+    mock = Mock()
+
+    service = DataService(mock)
+    result = service.process("data")
+
+    # Only verify the outcome
+    assert result.success
+    mock.save.assert_called()  # Called at some point
+```
+
+---
+
+## Best Practices
+
+### 1. Always Use autospec=True
+
+```python
+# GOOD
+@patch("mymodule.ExternalService", autospec=True)
+def test_with_autospec(mock_service):
+    """Mock respects real method signatures."""
+    ...
+
+# BAD
+@patch("mymodule.ExternalService")
+def test_without_autospec(mock_service):
+    """Can create invalid method calls."""
+    ...
+```
+
+### 2. Mock at System Boundaries
+
+```python
+# GOOD: Mock external API
+def test_mocks_at_boundary(monkeypatch):
+    """Mock the external dependency."""
+    mock_api_client = Mock()
+    service = MyService(api_client=mock_api_client)
+    ...
+
+# BAD: Mock internal logic
+def test_mocks_internal(monkeypatch):
+    """Don't mock your own code."""
+    service = MyService()
+    monkeypatch.setattr(service, "_internal_method", Mock())
+    ...
+```
+
+### 3. Use spec Keyword for Safety
+
+```python
+from mymodule import RealClass
+
+# GOOD: Mock with spec
+def test_with_spec():
+    """Mock can only access real attributes."""
+    mock = Mock(spec=RealClass)
+    mock.real_method.return_value = "value"
+    # mock.fake_method()  # AttributeError!
+
+# BAD: Mock without spec
+def test_without_spec():
+    """Mock accepts any attribute."""
+    mock = Mock()
+    mock.anything.works()  # Silently passes
+```
+
+### 4. Keep Mocks Simple
+
+```python
+# GOOD: Simple, focused mock
+def test_simple_mock():
+    """One mock, one purpose."""
+    mock_api = Mock()
+    mock_api.get_user.return_value = {"id": 123}
+
+    result = service.fetch_user(123)
+    assert result["id"] == 123
+
+# BAD: Complex mock setup
+def test_complex_mock():
+    """Too much mock configuration."""
+    mock = Mock()
+    mock.method.return_value.attribute.value.getter.return_value = "data"
+    # This is too complex!
+```
+
+### 5. Verify Mock Behavior
+
+```python
+# GOOD: Verify the mock was used correctly
+def test_verifies_mock():
+    """Verify mock behavior."""
+    mock = Mock()
+
+    service.process(mock, "data")
+
+    mock.save.assert_called_once_with("data")
+
+# BAD: Mock without verification
+def test_no_verification():
+    """Doesn't verify mock was used."""
+    mock = Mock()
+
+    service.process(mock, "data")
+    # No assertions about mock behavior!
+```
+
+### 6. Document Why Mocking Is Needed
+
+```python
+def test_aws_bedrock_with_mock(monkeypatch):
+    """Test AWS Bedrock integration.
+
+    Mocking rationale:
+    - Bedrock API calls cost money
+    - Network calls are slow
+    - Need to test error scenarios
+    - Want tests to run offline
+    """
+    mock_client = Mock(spec=BedrockClient)
+    ...
+```
+
+---
+
+## Drift-Specific Patterns
+
+### Pattern 1: Mock Provider (from tests/mock_provider.py)
+
+```python
+from tests.mock_provider import MockProvider
+
+def test_analyzer_with_mock_provider():
+    """Test analyzer with mock LLM provider."""
+    # Create and configure mock
+    mock_provider = MockProvider()
+    mock_provider.set_response('[{"type": "incomplete_work"}]')
+
+    # Run test
+    analyzer = DriftAnalyzer(provider=mock_provider)
+    result = analyzer.analyze(conversation)
+
+    # Verify
+    assert mock_provider.call_count == 1
+    assert "incomplete_work" in result
+```
+
+### Pattern 2: Import Error Mocking
+
+```python
+import sys
+
+def test_missing_anthropic_package(monkeypatch):
+    """Test handling of missing anthropic package."""
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+
+    with pytest.raises(RuntimeError, match="anthropic package required"):
+        provider = AnthropicProvider()
+
+def test_missing_tiktoken_package(monkeypatch):
+    """Test handling of missing tiktoken package."""
+    monkeypatch.setitem(sys.modules, "tiktoken", None)
+
+    with pytest.raises(RuntimeError, match="tiktoken package required"):
+        tokenizer = create_tokenizer("openai")
+```
+
+### Pattern 3: File Operation Mocking
+
+```python
+# Use tmp_path for happy path
+def test_reads_frontmatter(tmp_path):
+    """Test reading YAML frontmatter from real file."""
+    file = tmp_path / "test.md"
+    file.write_text("---\ntitle: Test\n---\nContent")
+
+    result = parse_frontmatter(file)
+    assert result["title"] == "Test"
+
+# Use monkeypatch for error cases
+def test_handles_file_read_error(monkeypatch):
+    """Test handling of file read errors."""
+    def mock_read_text():
+        raise IOError("Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+
+    with pytest.raises(IOError):
+        parse_frontmatter("file.md")
+```
+
+### Pattern 4: AWS Bedrock Mocking
+
+```python
+from unittest.mock import Mock, patch
+
+@patch("drift.providers.bedrock.boto3.client", autospec=True)
+def test_bedrock_token_counting(mock_boto_client):
+    """Test Bedrock token counting."""
+    # Setup mock client
+    mock_bedrock = Mock()
+    mock_bedrock.invoke_model.return_value = {
+        "body": json.dumps({"usage": {"input_tokens": 150}})
+    }
+    mock_boto_client.return_value = mock_bedrock
+
+    # Test
+    provider = BedrockProvider()
+    count = provider.count_tokens("test content")
+
+    # Verify
+    assert count == 150
+    mock_bedrock.invoke_model.assert_called_once()
+```
+
+---
+
+## Mocking Checklist
+
+Before using a mock in your test:
+
+- [ ] **Necessary?** Is mocking required or can I test with real dependency?
+- [ ] **Boundary?** Am I mocking at a system boundary, not internal logic?
+- [ ] **Tool choice?** Using appropriate tool (monkeypatch vs mock)?
+- [ ] **autospec?** Using `autospec=True` if using unittest.mock?
+- [ ] **Spec?** Using `spec` parameter for type safety?
+- [ ] **Behavior?** Does mock mimic real behavior accurately?
+- [ ] **Verification?** Am I verifying the mock was called correctly?
+- [ ] **Meaningful?** Is the test still meaningful with mocks?
+- [ ] **Documented?** Is it clear why mocking is necessary?
+- [ ] **Simple?** Is the mock setup as simple as possible?
+
+---
+
+## Quick Reference
+
+### Monkeypatch Examples
+
+```python
+# Set attribute
+monkeypatch.setattr(obj, "attribute", value)
+
+# Set item in dict
+monkeypatch.setitem(sys.modules, "package", None)
+
+# Set environment variable
+monkeypatch.setenv("API_KEY", "test_key")
+
+# Delete attribute
+monkeypatch.delattr(obj, "attribute")
+
+# Change directory
+monkeypatch.chdir(path)
+```
+
+### Mock Examples
+
+```python
+# Basic mock
+mock = Mock()
+mock.method.return_value = "value"
+
+# Mock with spec
+mock = Mock(spec=RealClass)
+
+# Patch decorator
+@patch("module.Class", autospec=True)
+def test_func(mock_class):
+    ...
+
+# Patch context manager
+with patch("module.function") as mock_func:
+    mock_func.return_value = "value"
+
+# Side effects (sequence of returns)
+mock.method.side_effect = [1, 2, 3]
+
+# Side effects (exception)
+mock.method.side_effect = Exception("Error")
+
+# Verify calls
+mock.method.assert_called_once()
+mock.method.assert_called_with(arg1, arg2)
+mock.method.assert_not_called()
+```
+
+### Remember
+
+**Mock at boundaries, test real internally.**

--- a/.claude/skills/test-strategy/resources/test-identification.md
+++ b/.claude/skills/test-strategy/resources/test-identification.md
@@ -1,0 +1,428 @@
+# Test Identification Guide
+
+Step-by-step process for identifying what tests need to be written.
+
+## From User Story to Test Cases
+
+### Step 1: Extract Requirements
+
+Read the user story and extract all explicit and implicit requirements.
+
+**Example: Block Line Count Validator**
+
+User story: "Create a validator that checks if code blocks in markdown files exceed a maximum line count"
+
+**Explicit requirements:**
+- R1: Find code blocks in markdown files
+- R2: Count lines in each code block
+- R3: Compare against max_count parameter
+- R4: Fail if any block exceeds max_count
+
+**Implicit requirements:**
+- R5: Handle files without code blocks
+- R6: Handle empty code blocks
+- R7: Handle multiple code blocks in one file
+- R8: Handle missing or invalid parameters
+- R9: Follow Drift validator contract (return None for pass, DocumentRule for fail)
+
+### Step 2: Identify All Behaviors
+
+For each requirement, list the specific behaviors that need testing.
+
+**From requirements above:**
+
+**R1 (Find code blocks):**
+- Behavior 1: Identify code blocks with triple backticks
+- Behavior 2: Handle files with no code blocks
+- Behavior 3: Handle multiple code blocks
+
+**R2 (Count lines):**
+- Behavior 4: Count only content lines, not fence markers
+- Behavior 5: Handle empty code blocks (0 lines)
+- Behavior 6: Count blank lines within blocks correctly
+
+**R3 (Compare against max):**
+- Behavior 7: Compare block line count to max_count
+- Behavior 8: Handle max_count boundary (equals case)
+
+**R4 (Fail if exceeds):**
+- Behavior 9: Return None when all blocks under limit
+- Behavior 10: Return DocumentRule when any block over limit
+- Behavior 11: Report which block and file exceeded limit
+
+**R5-R9 (Edge cases):**
+- Behavior 12: Pass when file has no code blocks
+- Behavior 13: Handle missing max_count parameter
+- Behavior 14: Handle invalid max_count (negative, zero)
+- Behavior 15: Work with DocumentBundle structure
+
+### Step 3: Categorize by Test Type
+
+Decide which behaviors need unit tests vs integration tests.
+
+**Unit Tests (test validator logic in isolation):**
+- All behaviors 1-14 above
+- Focus on validator logic, not file system or bundle creation
+
+**Integration Tests (test with real DocumentBundle):**
+- Behavior 15: End-to-end with DocumentBundle
+- Multiple files scenario
+- Real markdown parsing
+
+**E2E Tests (test in complete workflow):**
+- Not needed for individual validators
+- Covered by analyzer integration tests
+
+### Step 4: Map to Test Methods
+
+Convert each behavior to a test method name.
+
+```python
+class TestBlockLineCountValidator:
+    """Tests for BlockLineCountValidator."""
+
+    # R1 - Finding code blocks
+    def test_identifies_code_blocks_with_triple_backticks()
+    def test_passes_when_no_code_blocks()
+    def test_handles_multiple_code_blocks()
+
+    # R2 - Counting lines
+    def test_counts_only_block_content_not_fences()
+    def test_handles_empty_code_block()
+    def test_counts_blank_lines_within_block()
+
+    # R3, R4 - Comparison and failure
+    def test_passes_when_block_under_max()
+    def test_passes_when_block_equals_max()  # Boundary!
+    def test_fails_when_block_exceeds_max()
+    def test_fails_with_correct_error_message()
+    def test_reports_file_and_block_location()
+
+    # R5-R9 - Edge cases
+    def test_handles_missing_max_count_param()
+    def test_handles_zero_max_count()
+    def test_handles_negative_max_count()
+```
+
+### Step 5: Prioritize Tests
+
+Order tests by risk and importance:
+
+**Priority 1 (Must have - core functionality):**
+- test_passes_when_block_under_max
+- test_fails_when_block_exceeds_max
+- test_passes_when_block_equals_max (boundary)
+
+**Priority 2 (Important - common cases):**
+- test_handles_multiple_code_blocks
+- test_passes_when_no_code_blocks
+- test_reports_file_and_block_location
+
+**Priority 3 (Edge cases):**
+- test_handles_empty_code_block
+- test_handles_missing_max_count_param
+- test_counts_blank_lines_within_block
+
+---
+
+## From Code to Test Cases
+
+### New Code
+
+When writing tests for new code:
+
+1. **Read the implementation** - Understand what it does
+2. **Identify branches** - Every if/else needs both paths tested
+3. **Find loops** - Test empty, single, multiple iterations
+4. **Spot error handling** - Test each exception path
+5. **Look for parameters** - Test valid, invalid, boundary values
+
+**Example:**
+
+```python
+def validate_line_count(content, max_count):
+    if max_count <= 0:
+        raise ValueError("max_count must be positive")
+
+    blocks = extract_code_blocks(content)
+    if not blocks:
+        return None  # No blocks = pass
+
+    for block in blocks:
+        if len(block.lines) > max_count:
+            return create_failure(block)
+
+    return None
+```
+
+**Tests needed:**
+```python
+def test_raises_error_when_max_count_zero()       # if max_count <= 0
+def test_raises_error_when_max_count_negative()   # if max_count <= 0
+def test_passes_when_no_blocks()                  # if not blocks
+def test_fails_when_any_block_exceeds()           # if len > max_count
+def test_passes_when_all_blocks_under_limit()     # loop completes
+def test_handles_empty_blocks_list()              # blocks = []
+```
+
+### Code Changes
+
+When testing modifications to existing code:
+
+1. **Understand what changed** - Read the diff
+2. **Identify affected behaviors** - What behaviors are modified?
+3. **Check existing tests** - Do they still cover the change?
+4. **Add new tests** - For new behaviors introduced
+5. **Update existing tests** - If behavior contracts changed
+
+**Example change:** Add support for inline code (single backticks)
+
+**New tests needed:**
+```python
+def test_ignores_inline_code()                    # NEW behavior
+def test_handles_mix_of_inline_and_block_code()  # NEW behavior
+```
+
+**Existing tests to verify:**
+- Ensure existing tests still pass
+- Verify they don't need updates
+
+### Bug Fixes
+
+When fixing a bug, always add a regression test:
+
+1. **Write failing test** - Reproduces the bug
+2. **Fix the bug** - Make the test pass
+3. **Verify fix** - Run all tests
+
+**Example bug:** Validator crashes on files with unclosed code blocks
+
+**Regression test:**
+```python
+def test_handles_unclosed_code_block():
+    """Test that unclosed code blocks don't crash validator.
+
+    Regression test for bug #123.
+    """
+    content = "```python\ncode without closing fence"
+    # Should not crash, should handle gracefully
+    result = validate(content, max_count=10)
+    assert result is not None  # Should fail validation
+    assert "unclosed" in result.message.lower()
+```
+
+---
+
+## Test Type Decision Matrix
+
+### Unit Test When:
+
+**Testing:**
+- Single function/method
+- Validator logic
+- Data model validation
+- Utility functions
+- Parser logic
+- Format functions
+
+**Characteristics:**
+- Fast (< 100ms each)
+- Isolated (no external dependencies)
+- Mocked (file system, APIs, etc.)
+- Focused (one behavior per test)
+
+**Drift Examples:**
+- `test_yaml_frontmatter_validator.py` - Validator logic
+- `test_circular_dependencies_validator.py` - Graph algorithm
+- `test_block_line_count_validator.py` - Line counting logic
+
+### Integration Test When:
+
+**Testing:**
+- Component interaction
+- Validator with DocumentBundle
+- Config loading from files
+- Multi-phase workflows
+- File system operations
+
+**Characteristics:**
+- Slower (< 1s each)
+- Uses real components together
+- May use tmp_path for files
+- Tests workflows, not individual functions
+
+**Drift Examples:**
+- `test_analyzer_multi_phase.py` - Full analysis workflow
+- `test_plugin_system.py` - Custom validator loading
+- `test_multi_file_statistics.py` - Statistics across files
+
+### E2E Test When:
+
+**Testing:**
+- Complete user workflows
+- Full CLI commands
+- Real configuration files
+- End-to-end scenarios
+
+**Characteristics:**
+- Slowest (< 5s each)
+- Uses real everything
+- Minimal mocking
+- Tests user-visible behavior
+
+**Drift Examples:**
+- CLI integration tests
+- Full `drift --no-llm` workflow
+- Complete analysis pipeline
+
+### Decision Flow:
+
+```
+Is it a single function/method?
+├─ YES → Unit Test
+└─ NO
+   │
+   Is it multiple components working together?
+   ├─ YES → Integration Test
+   └─ NO
+      │
+      Is it a complete user workflow?
+      ├─ YES → E2E Test
+      └─ NO → Start with Unit Test, add Integration if needed
+```
+
+---
+
+## Practical Examples
+
+### Example 1: Circular Dependency Validator
+
+**User Story:** "Detect circular dependencies in skill definitions"
+
+**Requirements:**
+- R1: Parse skill dependencies from frontmatter
+- R2: Build dependency graph
+- R3: Detect cycles in graph
+- R4: Report which skills form the cycle
+
+**Test Plan:**
+
+```python
+class TestCircularDependenciesValidator:
+    # R1 - Parsing
+    def test_parses_dependencies_from_frontmatter()
+    def test_handles_no_dependencies()
+    def test_handles_invalid_frontmatter()
+
+    # R2 - Graph building
+    def test_builds_graph_with_single_dependency()
+    def test_builds_graph_with_multiple_dependencies()
+
+    # R3 - Cycle detection
+    def test_passes_when_no_cycles()
+    def test_detects_self_loop()           # A → A
+    def test_detects_two_node_cycle()      # A → B → A
+    def test_detects_multi_node_cycle()    # A → B → C → A
+
+    # R4 - Reporting
+    def test_reports_skills_in_cycle()
+    def test_reports_file_locations()
+```
+
+**Prioritization:**
+1. Core: test_detects_two_node_cycle (most common)
+2. Important: test_passes_when_no_cycles (happy path)
+3. Edge: test_detects_self_loop, test_detects_multi_node_cycle
+
+### Example 2: YAML Schema Validator
+
+**User Story:** "Validate YAML frontmatter against JSON schema"
+
+**Requirements:**
+- R1: Extract YAML frontmatter
+- R2: Parse JSON schema from rule
+- R3: Validate YAML against schema
+- R4: Report validation errors clearly
+
+**Test Plan:**
+
+```python
+class TestYAMLSchemaValidator:
+    # R1 - Extraction
+    def test_extracts_yaml_frontmatter()
+    def test_handles_no_frontmatter()
+    def test_handles_malformed_yaml()
+
+    # R2 - Schema parsing
+    def test_parses_json_schema_from_rule()
+    def test_handles_missing_schema_param()
+    def test_handles_invalid_json_schema()
+
+    # R3 - Validation
+    def test_passes_when_yaml_matches_schema()
+    def test_fails_when_required_field_missing()
+    def test_fails_when_field_wrong_type()
+    def test_fails_when_field_invalid_value()
+
+    # R4 - Error reporting
+    def test_reports_which_field_failed()
+    def test_reports_expected_vs_actual()
+    def test_includes_file_location()
+```
+
+---
+
+## Checklist
+
+Use this checklist when planning tests for a new feature:
+
+- [ ] Read and understand the user story/issue
+- [ ] Extract all explicit requirements
+- [ ] Identify implicit requirements (error handling, edge cases)
+- [ ] List all behaviors for each requirement
+- [ ] Categorize behaviors by test type (unit/integration/e2e)
+- [ ] Map each behavior to a test method name
+- [ ] Prioritize tests by risk/importance
+- [ ] Identify edge cases using equivalence partitioning
+- [ ] Identify boundary conditions to test
+- [ ] Plan fixture requirements
+- [ ] Review similar tests in codebase for patterns
+- [ ] Verify 90%+ coverage will be achieved
+
+---
+
+## Common Patterns
+
+### Pattern 1: Validator Testing
+
+Every validator needs:
+```python
+def test_validation_type_property()        # Verify validation_type
+def test_passes_when_valid()               # Happy path
+def test_fails_when_invalid()              # Failure path
+def test_fails_with_clear_message()        # Error message quality
+def test_handles_missing_parameters()      # Config edge case
+def test_handles_file_not_found()          # File edge case
+```
+
+### Pattern 2: Parser Testing
+
+Every parser needs:
+```python
+def test_parses_valid_input()              # Happy path
+def test_raises_error_on_invalid_syntax()  # Syntax error
+def test_raises_error_on_invalid_schema()  # Schema error
+def test_handles_empty_input()             # Empty edge case
+def test_handles_malformed_input()         # Malformed edge case
+```
+
+### Pattern 3: CLI Testing
+
+Every CLI command needs:
+```python
+def test_successful_execution()            # Happy path
+def test_handles_missing_file()            # File error
+def test_handles_invalid_arguments()       # Arg error
+def test_output_format_correct()           # Output verification
+def test_exit_code_correct()               # Exit code verification
+```

--- a/.claude/skills/test-strategy/resources/test-organization.md
+++ b/.claude/skills/test-strategy/resources/test-organization.md
@@ -1,0 +1,844 @@
+# Test Organization Patterns
+
+How to organize tests in Drift for maintainability and clarity.
+
+## Directory Structure
+
+### Standard Layout
+
+```
+tests/
+├── __init__.py              # Makes tests a package
+├── conftest.py              # Shared fixtures and configuration
+├── test_utils.py            # Testing utilities (CliRunner, etc.)
+├── mock_provider.py         # Mock implementations
+├── fixtures/                # Static test data
+│   ├── sample_bedrock_response.json
+│   ├── sample_config.yaml
+│   └── sample_conversation.jsonl
+├── unit/                    # Unit tests (80-90% of tests)
+│   ├── __init__.py
+│   ├── test_validators/
+│   │   ├── test_yaml_frontmatter_validator.py
+│   │   ├── test_block_line_count_validator.py
+│   │   └── ...
+│   ├── test_analyzer.py
+│   ├── test_config_loader.py
+│   └── ...
+└── integration/             # Integration tests (10-15%)
+    ├── __init__.py
+    ├── test_analyzer_workflows.py
+    ├── test_plugin_system.py
+    └── ...
+```
+
+### Directory Purpose
+
+**`tests/`** - Root test directory
+- Contains shared test utilities
+- conftest.py with project-wide fixtures
+- Static test data in fixtures/
+
+**`tests/unit/`** - Unit tests
+- Test individual components in isolation
+- Mock external dependencies
+- Fast execution (< 100ms per test)
+- 70-80 test files in Drift
+
+**`tests/integration/`** - Integration tests
+- Test component interactions
+- May use real file system (tmp_path)
+- Slower execution (< 1s per test)
+- 10-15 test files in Drift
+
+**`tests/e2e/`** - End-to-end tests (if needed)
+- Full user workflows
+- Real configurations
+- Slowest execution (< 5s per test)
+
+### File Naming
+
+**Pattern:** `test_<module>_<feature>.py`
+
+**Examples:**
+```
+test_yaml_frontmatter_validator.py
+test_block_line_count_validator.py
+test_circular_dependencies_validator.py
+test_analyzer_multi_phase.py
+test_config_loader.py
+```
+
+**Rules:**
+- Start with `test_` (pytest requirement)
+- Descriptive of what's being tested
+- One test file per major component
+- Group related tests together
+
+---
+
+## Test Class Organization
+
+### Standard Pattern
+
+```python
+class Test<Component>:
+    """Tests for <Component>.
+
+    <Brief description of what the component does>
+    """
+
+    # Fixtures first (setup methods)
+    @pytest.fixture
+    def component(self):
+        """Create component instance.
+
+        Returns:
+            Component: Configured instance for testing
+        """
+        return Component()
+
+    @pytest.fixture
+    def test_data(self, tmp_path):
+        """Create test data.
+
+        Args:
+            tmp_path: Pytest fixture for temporary directory
+
+        Returns:
+            TestData: Sample data for tests
+        """
+        return create_test_data(tmp_path)
+
+    # Happy path tests (success cases)
+    def test_succeeds_when_valid_input(self, component, test_data):
+        """Test that component succeeds with valid input."""
+        result = component.process(test_data)
+        assert result.success is True
+
+    # Failure tests (expected failures)
+    def test_fails_when_invalid_input(self, component):
+        """Test that component fails with invalid input."""
+        result = component.process(invalid_data)
+        assert result.success is False
+        assert "invalid" in result.error
+
+    # Edge case tests
+    def test_handles_empty_input(self, component):
+        """Test that component handles empty input gracefully."""
+        result = component.process("")
+        assert result is not None
+
+    # Error handling tests
+    def test_raises_error_when_required_missing(self, component):
+        """Test that component raises error when required param missing."""
+        with pytest.raises(ValueError, match="required"):
+            component.process(None)
+```
+
+### Grouping Within Class
+
+**Group tests by:**
+1. Test type (happy/failure/edge/error)
+2. Feature area
+3. Specific method being tested
+
+**Example from YamlFrontmatterValidator:**
+```python
+class TestYamlFrontmatterValidator:
+    """Tests for YamlFrontmatterValidator."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return YamlFrontmatterValidator()
+
+    # === Valid frontmatter tests ===
+    def test_passes_with_valid_frontmatter(self):
+        """Test validation passes with valid YAML frontmatter."""
+
+    def test_passes_with_empty_frontmatter(self):
+        """Test validation passes with empty frontmatter."""
+
+    # === Invalid frontmatter tests ===
+    def test_fails_with_invalid_yaml(self):
+        """Test validation fails with malformed YAML."""
+
+    def test_fails_with_unclosed_frontmatter(self):
+        """Test validation fails with unclosed frontmatter."""
+
+    # === Schema validation tests ===
+    def test_passes_when_matches_schema(self):
+        """Test validation passes when YAML matches schema."""
+
+    def test_fails_when_missing_required_field(self):
+        """Test validation fails when required field missing."""
+
+    # === Error handling tests ===
+    def test_handles_file_not_found(self):
+        """Test validator handles missing file gracefully."""
+```
+
+---
+
+## Test Method Naming
+
+### Convention
+
+**Pattern:** `test_<component>_<behavior>_<condition>`
+
+**Or shorter:** `test_<behavior>_<condition>`
+
+**Parts:**
+- `test_` - Required prefix
+- `<component>` - Optional, what is being tested
+- `<behavior>` - What happens (passes, fails, raises, returns, etc.)
+- `<condition>` - When/why (when valid, when missing, with empty, etc.)
+
+### Good Names
+
+```python
+def test_validator_passes_when_within_limit()
+def test_parser_raises_error_on_invalid_json()
+def test_analyzer_skips_disabled_rules()
+def test_formatter_includes_file_paths()
+def test_loader_merges_project_over_global_config()
+```
+
+**Why they're good:**
+- Clear what's being tested
+- Clear what the expected behavior is
+- Clear under what conditions
+- Self-documenting
+
+### Bad Names
+
+```python
+def test_validator()                  # Too vague
+def test_case_1()                     # No context
+def test_validator_test()             # Redundant
+def test_this_should_work()           # Unclear
+def test_function()                   # What function? What about it?
+```
+
+**Why they're bad:**
+- Don't explain what's being tested
+- Don't explain expected behavior
+- Hard to understand when they fail
+- Not maintainable
+
+### Drift Examples
+
+**From test_yaml_frontmatter_validator.py:**
+```python
+def test_validation_type(self)
+def test_passes_with_valid_frontmatter(self)
+def test_fails_with_invalid_yaml(self)
+def test_fails_with_missing_required_field(self)
+def test_handles_unclosed_frontmatter(self)
+```
+
+**From test_circular_dependencies_validator.py:**
+```python
+def test_detects_self_loop(self)
+def test_detects_two_node_cycle(self)
+def test_passes_with_no_cycles(self)
+def test_reports_cycle_participants(self)
+```
+
+---
+
+## Fixture Management
+
+### Fixture Hierarchy
+
+**Three levels:**
+
+1. **Project-level** (conftest.py at root)
+2. **Module-level** (test_*.py file)
+3. **Class-level** (within test class)
+
+```python
+# tests/conftest.py - PROJECT LEVEL
+@pytest.fixture
+def temp_dir():
+    """Temporary directory for all tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+@pytest.fixture
+def sample_drift_config():
+    """Standard Drift configuration for testing."""
+    return DriftConfig(...)
+
+# tests/unit/test_validators.py - MODULE LEVEL
+@pytest.fixture
+def sample_bundle(tmp_path):
+    """Standard DocumentBundle for validator tests."""
+    return DocumentBundle(...)
+
+# Within test class - CLASS LEVEL
+class TestMyValidator:
+    @pytest.fixture
+    def validator(self):
+        """Validator instance for this test class."""
+        return MyValidator()
+
+    @pytest.fixture
+    def rule(self):
+        """Validation rule for this test class."""
+        return ValidationRule(max_count=100)
+```
+
+### Fixture Composition
+
+**Build complex fixtures from simpler ones:**
+
+```python
+# Simple fixtures
+@pytest.fixture
+def sample_provider_config():
+    return ProviderConfig(provider="bedrock", ...)
+
+@pytest.fixture
+def sample_model_config():
+    return ModelConfig(model_id="haiku", ...)
+
+@pytest.fixture
+def sample_rule_definition():
+    return RuleDefinition(rule_id="test", ...)
+
+# Composed fixture
+@pytest.fixture
+def sample_drift_config(
+    sample_provider_config,
+    sample_model_config,
+    sample_rule_definition
+):
+    """Complete Drift config from component fixtures."""
+    return DriftConfig(
+        providers={"bedrock": sample_provider_config},
+        models={"haiku": sample_model_config},
+        rule_definitions={"rule": sample_rule_definition},
+    )
+```
+
+**Benefits:**
+- Reusable components
+- Easy to customize
+- Clear dependencies
+- Maintainable
+
+### Fixture Scopes
+
+**Choose appropriately:**
+
+```python
+@pytest.fixture(scope="session")
+def expensive_setup():
+    """Created once per test session.
+
+    Use for:
+    - Database connections
+    - External service setup
+    - Expensive computations
+    """
+    setup = ExpensiveSetup()
+    yield setup
+    setup.teardown()
+
+@pytest.fixture(scope="module")
+def shared_resource():
+    """Created once per test module.
+
+    Use for:
+    - Shared test data
+    - Module-level mocks
+    - Common configuration
+    """
+    return SharedResource()
+
+@pytest.fixture(scope="function")  # Default
+def isolated_data():
+    """Created for each test function.
+
+    Use for:
+    - Test-specific data
+    - Mutable objects
+    - Anything that needs isolation
+    """
+    return IsolatedData()
+```
+
+**Drift examples:**
+```python
+@pytest.fixture  # function scope (default)
+def validator(self):
+    """New instance for each test - ensures isolation."""
+    return BlockLineCountValidator()
+
+@pytest.fixture  # function scope
+def bundle(self, tmp_path):
+    """New bundle for each test - prevents state sharing."""
+    return create_bundle(tmp_path)
+```
+
+### Factory Fixtures
+
+**For customizable test data:**
+
+```python
+@pytest.fixture
+def make_bundle():
+    """Factory for creating custom bundles.
+
+    Returns:
+        Callable: Function to create bundles with custom parameters
+    """
+    def _make_bundle(bundle_type="skill", num_files=1, content="test"):
+        files = [
+            DocumentFile(
+                relative_path=f"file{i}.md",
+                content=content,
+                file_path=f"/test/file{i}.md"
+            )
+            for i in range(num_files)
+        ]
+        return DocumentBundle(
+            bundle_id=f"test-{bundle_type}",
+            bundle_type=bundle_type,
+            bundle_strategy="individual",
+            files=files,
+            project_path="/test"
+        )
+    return _make_bundle
+
+# Usage in tests
+def test_with_custom_bundle(make_bundle):
+    """Test with custom bundle configuration."""
+    # Create bundle with 3 files
+    bundle = make_bundle(bundle_type="command", num_files=3)
+
+    # Create bundle with specific content
+    bundle = make_bundle(content="# Custom content")
+```
+
+---
+
+## Test Data Management
+
+### Strategy 1: Inline Data
+
+**For simple, one-off test data:**
+
+```python
+def test_parses_valid_frontmatter():
+    """Test parsing of valid YAML frontmatter."""
+    content = """---
+title: Test Document
+description: Sample
+---
+# Content here
+"""
+    result = parse_frontmatter(content)
+    assert result["title"] == "Test Document"
+```
+
+**When to use:**
+- Simple data
+- One-time use
+- Easy to understand inline
+
+### Strategy 2: Fixture Data
+
+**For reusable test data:**
+
+```python
+@pytest.fixture
+def sample_conversation():
+    """Sample conversation for testing."""
+    return Conversation(
+        session_id="test-123",
+        turns=[
+            Turn(role="user", content="Hello"),
+            Turn(role="assistant", content="Hi there"),
+        ],
+        metadata={"tool": "claude-code"}
+    )
+
+def test_analyzes_conversation(sample_conversation):
+    """Test conversation analysis."""
+    result = analyze(sample_conversation)
+    assert result is not None
+```
+
+**When to use:**
+- Reused across multiple tests
+- Complex data structures
+- Shared test state
+
+### Strategy 3: tmp_path for Files
+
+**For file-based testing:**
+
+```python
+def test_reads_config_file(tmp_path):
+    """Test reading configuration from file."""
+    # Create test file
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+providers:
+  bedrock:
+    region: us-east-1
+""")
+
+    # Test with file
+    config = load_config(config_file)
+    assert config.providers["bedrock"].region == "us-east-1"
+```
+
+**When to use:**
+- Testing file operations
+- Need actual files
+- Testing path handling
+
+**Benefits:**
+- Automatic cleanup
+- Isolated per test
+- Real file operations
+
+### Strategy 4: Parametrize for Variations
+
+**For testing multiple inputs:**
+
+```python
+@pytest.mark.parametrize("provider,expected_tokenizer", [
+    ("anthropic", "anthropic tokenizer"),
+    ("openai", "openai tokenizer"),
+    ("llama", "llama tokenizer"),
+    ("unknown", "default tokenizer"),
+])
+def test_tokenizer_selection(provider, expected_tokenizer):
+    """Test tokenizer selection for different providers."""
+    result = select_tokenizer(provider)
+    assert result == expected_tokenizer
+```
+
+**When to use:**
+- Same test logic, different inputs
+- Testing boundaries
+- Multiple similar scenarios
+
+**Benefits:**
+- Less code duplication
+- Clear test cases
+- Easy to add cases
+
+### Strategy 5: Static Fixtures
+
+**For unchanging test data:**
+
+```
+tests/fixtures/
+├── sample_bedrock_response.json
+├── sample_config.yaml
+└── sample_conversation.jsonl
+```
+
+```python
+@pytest.fixture
+def sample_bedrock_response():
+    """Load sample Bedrock API response."""
+    path = Path(__file__).parent / "fixtures" / "sample_bedrock_response.json"
+    return json.loads(path.read_text())
+
+def test_parses_bedrock_response(sample_bedrock_response):
+    """Test parsing of Bedrock API response."""
+    result = parse_response(sample_bedrock_response)
+    assert result is not None
+```
+
+**When to use:**
+- Large test data
+- Real examples
+- API responses
+
+---
+
+## Patterns from Drift Codebase
+
+### Pattern 1: DocumentBundle Creation
+
+**Standard pattern for validator tests:**
+
+```python
+@pytest.fixture
+def bundle(self, tmp_path):
+    """Create DocumentBundle with test file."""
+    # Create test file
+    test_file = tmp_path / "test.md"
+    test_file.write_text("# Test\nContent")
+
+    # Create DocumentBundle
+    return DocumentBundle(
+        bundle_id="test-bundle",
+        bundle_type="skill",
+        bundle_strategy="individual",
+        files=[
+            DocumentFile(
+                relative_path="test.md",
+                content="# Test\nContent",
+                file_path=str(test_file),
+            )
+        ],
+        project_path=tmp_path,
+    )
+```
+
+### Pattern 2: Validator Testing Template
+
+**Standard structure for validator tests:**
+
+```python
+class TestMyValidator:
+    """Tests for MyValidator."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return MyValidator()
+
+    @pytest.fixture
+    def bundle(self, tmp_path):
+        """Create test bundle."""
+        # ... create bundle ...
+        return bundle
+
+    def test_validation_type(self, validator):
+        """Test validation_type property."""
+        assert validator.validation_type == "expected:type"
+
+    def test_passes_when_valid(self, validator, bundle):
+        """Test validation passes with valid input."""
+        rule = ValidationRule(param=value)
+        result = validator.validate(rule, bundle)
+        assert result is None  # None = pass
+
+    def test_fails_when_invalid(self, validator, bundle):
+        """Test validation fails with invalid input."""
+        rule = ValidationRule(param=bad_value)
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "expected error" in result.observed_issue
+
+    def test_handles_edge_case(self, validator, bundle):
+        """Test validator handles edge case."""
+        # ... test edge case ...
+```
+
+### Pattern 3: Mock Provider
+
+**For testing LLM interactions:**
+
+```python
+def test_analyzes_with_mock_provider(monkeypatch):
+    """Test analysis with mocked LLM provider."""
+    # Create mock
+    mock_client = Mock()
+    mock_client.count_tokens.return_value = 500
+
+    mock_anthropic = Mock()
+    mock_anthropic.Anthropic.return_value = mock_client
+
+    # Patch import
+    monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+
+    # Test with mock
+    result = analyze_content("test content")
+    assert result is not None
+    mock_client.count_tokens.assert_called_once()
+```
+
+### Pattern 4: CLI Testing
+
+**Using custom CliRunner:**
+
+```python
+from tests.test_utils import CliRunner
+
+def test_cli_command():
+    """Test CLI command execution."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--no-llm", "--format", "json"]
+    )
+
+    assert result.exit_code == 0
+    assert "output" in result.stdout
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+### ❌ Tests Sharing State
+
+```python
+# BAD - Shared state
+class TestValidator:
+    validator = Validator()  # Shared across tests!
+
+    def test_one(self):
+        self.validator.state = "modified"
+
+    def test_two(self):
+        # Depends on test_one's state!
+        assert self.validator.state == "modified"
+```
+
+```python
+# GOOD - Isolated state
+class TestValidator:
+    @pytest.fixture
+    def validator(self):
+        """New instance per test."""
+        return Validator()
+
+    def test_one(self, validator):
+        validator.state = "modified"
+        assert validator.state == "modified"
+
+    def test_two(self, validator):
+        # Fresh instance, no dependencies
+        assert validator.state == "initial"
+```
+
+### ❌ Test Order Dependencies
+
+```python
+# BAD - Tests depend on order
+def test_step1():
+    global result
+    result = compute()
+
+def test_step2():
+    # Fails if test_step1 doesn't run first!
+    assert result == expected
+```
+
+```python
+# GOOD - Independent tests
+def test_computes_correctly():
+    result = compute()
+    assert result == expected
+
+def test_uses_computed_result():
+    result = compute()  # Compute in this test
+    output = use_result(result)
+    assert output is not None
+```
+
+### ❌ Over-Complex Tests
+
+```python
+# BAD - Testing too many things
+def test_everything():
+    # Parse frontmatter
+    frontmatter = parse(content)
+    # Validate against schema
+    valid = validate(frontmatter)
+    # Format output
+    output = format(valid)
+    # Write to file
+    write(output)
+    # Read back
+    result = read()
+    # ... too much!
+```
+
+```python
+# GOOD - Focused tests
+def test_parses_frontmatter():
+    frontmatter = parse(content)
+    assert frontmatter["title"] == "Test"
+
+def test_validates_against_schema():
+    valid = validate(frontmatter, schema)
+    assert valid is True
+
+def test_formats_output():
+    output = format(valid_data)
+    assert "title" in output
+```
+
+### ❌ Brittle Assertions
+
+```python
+# BAD - Fragile string matching
+def test_error_message():
+    result = validator.validate(rule, bundle)
+    assert result.observed_issue == "File test.md line 45 exceeds maximum of 100 lines (found 150)"
+```
+
+```python
+# GOOD - Flexible assertions
+def test_error_message():
+    result = validator.validate(rule, bundle)
+    assert "test.md" in result.observed_issue
+    assert "exceeds maximum" in result.observed_issue
+    assert "100" in result.observed_issue
+    assert "150" in result.observed_issue
+```
+
+---
+
+## Organization Checklist
+
+When organizing tests, verify:
+
+- [ ] Tests in correct directory (unit/integration/e2e)
+- [ ] File named `test_<module>.py`
+- [ ] Test class named `Test<Component>`
+- [ ] Fixtures before test methods
+- [ ] Tests grouped logically (happy/failure/edge/error)
+- [ ] Clear test method names
+- [ ] Appropriate fixture scopes
+- [ ] No shared state between tests
+- [ ] No test order dependencies
+- [ ] Tests are independent and isolated
+- [ ] Each test has clear, focused assertions
+- [ ] Test docstrings explain what/why
+
+---
+
+## Quick Reference
+
+### File Structure
+```
+tests/unit/test_<component>.py
+```
+
+### Class Structure
+```python
+class Test<Component>:
+    @pytest.fixture
+    def component(self):
+        return Component()
+
+    def test_<behavior>_<condition>(self, component):
+        result = component.method()
+        assert result == expected
+```
+
+### Naming
+- Files: `test_<module>.py`
+- Classes: `Test<Component>`
+- Methods: `test_<behavior>_<condition>`
+- Fixtures: descriptive noun
+
+### Fixtures
+- Project: `tests/conftest.py`
+- Module: Top of `test_*.py`
+- Class: Inside `Test*` class
+- Scope: function (default), module, session

--- a/.drift_rules.yaml
+++ b/.drift_rules.yaml
@@ -1,6 +1,5 @@
 # Drift Rules File - Consolidated by Resource Type
 # Validation rules for the Drift project
-# This file is automatically loaded by drift when .drift_rules.yaml exists in the project root
 #
 # ORGANIZATION: Rules are organized by resource type (skills, agents, commands, etc.)
 # Each rule contains multiple phases that validate different aspects of that resource type.
@@ -29,16 +28,18 @@ skill_validation:
     # Phase 1: File existence and naming
     - name: check_file_exists
       type: core:file_exists
-      file_path: .claude/skills/*/SKILL.md
+      params:
+        file_path: .claude/skills/*/SKILL.md
       failure_message: "Found skill directory with skill.md (lowercase) instead of SKILL.md (uppercase)"
       expected_behavior: "All skill directories should contain SKILL.md (uppercase) as the main skill file"
 
     # Phase 2: Frontmatter validation
     - name: check_frontmatter_required_fields
       type: core:yaml_frontmatter
-      required_fields:
-        - name
-        - description
+      params:
+        required_fields:
+          - name
+          - description
       failure_message: "Skill frontmatter must include 'name' and 'description' fields"
       expected_behavior: "All skills must have valid YAML frontmatter with 'name' and 'description' fields"
 
@@ -253,10 +254,8 @@ agent_validation:
                 type: string
               description: "Optional list of skill names"
             tools:
-              type: array
-              items:
-                type: string
-              description: "Optional list of tool names"
+              type: string
+              description: "Optional comma-separated list of tool names"
           required:
             - name
             - description
@@ -464,8 +463,12 @@ command_validation:
                 type: string
               description: "Optional list of skill names to activate"
             argument-hint:
-              type: string
-              description: "Optional hint for command arguments during tab-completion"
+              oneOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
+              description: "Optional hint(s) for command arguments during tab-completion"
           required:
             - description
       failure_message: "Command file has invalid or missing YAML frontmatter"
@@ -700,19 +703,34 @@ claude_md_validation:
     # Phase 1: File existence
     - name: check_file_exists
       type: core:file_exists
-      file_path: CLAUDE.md
+      params:
+        file_path: CLAUDE.md
       failure_message: "CLAUDE.md file is missing from project root"
       expected_behavior: "Project should have CLAUDE.md file documenting structure and conventions"
 
     # Phase 2: Line count check
     - name: check_line_count
       type: core:file_size
-      file_path: CLAUDE.md
-      max_count: 300
+      params:
+        file_path: CLAUDE.md
+        max_count: 300
       failure_message: "CLAUDE.md exceeds 300 lines (best practice for concise context)"
       expected_behavior: "CLAUDE.md should be concise and under 300 lines"
 
-    # Phase 3: Content quality
+    # Phase 3: Check code blocks aren't too long
+    - name: check_code_blocks_concise
+      type: core:block_line_count
+      description: "Ensure code examples in CLAUDE.md are concise"
+      params:
+        pattern_start: "^```"
+        pattern_end: "^```"
+        max_lines: 20
+        files:
+          - "CLAUDE.md"
+      failure_message: "Code block at CLAUDE.md:{line_start}-{line_end} has {actual_count} lines (expected at most {threshold})"
+      expected_behavior: "Code examples in CLAUDE.md should be brief (max 20 lines) to keep context concise"
+
+    # Phase 4: Content quality
     - name: check_content_quality
       type: prompt
       model: haiku
@@ -768,7 +786,7 @@ claude_md_validation:
         ONLY REPORT issues that significantly impact quality or violate best practices.
       available_resources: []
 
-    # Phase 4: Import syntax check
+    # Phase 5: Import syntax check
     - name: check_import_syntax
       type: prompt
       model: haiku
@@ -794,7 +812,7 @@ claude_md_validation:
         Focus: Are imports used correctly if present?
       available_resources: []
 
-    # Phase 5: Component documentation check
+    # Phase 6: Component documentation check
     - name: check_component_documentation
       type: prompt
       model: haiku

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,3 @@ Drift supports multiple LLM providers:
 - **Claude Code**: Use existing Claude Code CLI (no API key needed)
 
 Configuration in `.drift.yaml` (see README.md for details).
-
-## Validation Rules
-
-Two categories of validation:
-1. **Project Validation** (Programmatic): Primary use case - fast checks for documentation, dependencies, links, configuration. Define your standards in `.drift.yaml` and validate against them. Zero API calls needed.
-2. **Conversation Analysis** (LLM-based): Optional - analyzes AI agent conversations for quality issues. Requires LLM provider configuration.
-
-See `.drift.yaml` for full rule definitions and README.md for descriptions.

--- a/src/drift/core/analyzer.py
+++ b/src/drift/core/analyzer.py
@@ -1251,13 +1251,18 @@ as JSON."""
                         # Unknown type - skip
                         continue
 
-                    rule = ValidationRule(
+                    # Merge legacy phase fields into params for backward compatibility
+                    phase_params = dict(phase.params) if phase.params else {}
+                    if phase.file_path and "file_path" not in phase_params:
+                        phase_params["file_path"] = phase.file_path
+
+                    rule = ValidationRule(  # type: ignore[call-arg]
                         rule_type=phase.type,
                         description=type_config.description,
+                        params=phase_params,
                         file_path=phase.file_path,
                         failure_message=phase.failure_message,
                         expected_behavior=phase.expected_behavior,
-                        **phase.params,
                     )
 
                     result = registry.execute_rule(rule, bundle)

--- a/src/drift/validation/validators/__init__.py
+++ b/src/drift/validation/validators/__init__.py
@@ -21,6 +21,7 @@ from drift.validation.validators.client import (
     ClaudeSkillSettingsValidator,
 )
 from drift.validation.validators.core import (
+    BlockLineCountValidator,
     CircularDependenciesValidator,
     DependencyDuplicateValidator,
     FileExistsValidator,
@@ -109,6 +110,8 @@ class ValidatorRegistry:
             ListMatchValidator(self.loader),
             ListRegexMatchValidator(self.loader),
             MarkdownLinkValidator(self.loader),
+            # Block validators
+            BlockLineCountValidator(self.loader),
             # Dependency validators
             DependencyDuplicateValidator(self.loader),
             CircularDependenciesValidator(self.loader),

--- a/src/drift/validation/validators/base.py
+++ b/src/drift/validation/validators/base.py
@@ -1,4 +1,49 @@
-"""Base validator class for rule-based document validation."""
+"""Base validator class for rule-based document validation.
+
+VALIDATOR PARAMETER ARCHITECTURE
+================================
+
+Validators use a strict parameter architecture to ensure consistency:
+
+**Core Rule Fields** (defined in ValidationRule model):
+    - type: Validation type (required, e.g., "core:file_exists")
+    - description: Human-readable description (required)
+    - failure_message: Custom failure message (optional)
+    - expected_behavior: Expected behavior description (optional)
+
+**Validator-Specific Parameters** (under params dict):
+    ALL validator-specific parameters MUST go under the `params` dictionary.
+    This includes file paths, patterns, counts, sizes, flags, etc.
+
+    Examples:
+        params:
+            file_path: "CLAUDE.md"
+            pattern: "^```"
+            flags: 8
+            max_count: 300
+            required_fields: ["name", "description"]
+
+**Configuration Example**:
+    # .drift_rules.yaml
+    phases:
+        - name: check_file_exists
+          type: core:file_exists
+          params:
+              file_path: CLAUDE.md
+          failure_message: "CLAUDE.md missing"
+          expected_behavior: "Should have CLAUDE.md"
+
+**Implementation Pattern**:
+    All validators MUST read parameters from rule.params:
+
+        def validate(self, rule, bundle, all_bundles=None):
+            if not rule.params:
+                raise ValueError("Validator requires params")
+
+            param_value = rule.params.get("param_name")
+            if not param_value:
+                raise ValueError("Validator requires params.param_name")
+"""
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Literal, Optional
@@ -8,7 +53,11 @@ from drift.core.types import DocumentBundle, DocumentRule
 
 
 class BaseValidator(ABC):
-    """Abstract base class for all validators."""
+    """Abstract base class for all validators.
+
+    Validators implement specific validation logic and should follow the
+    parameter architecture documented in this module's docstring.
+    """
 
     def __init__(self, loader: Any = None):
         """Initialize validator.

--- a/src/drift/validation/validators/core/__init__.py
+++ b/src/drift/validation/validators/core/__init__.py
@@ -1,5 +1,6 @@
 """Core validators for generic validation tasks."""
 
+from drift.validation.validators.core.block_validators import BlockLineCountValidator
 from drift.validation.validators.core.circular_dependencies_validator import (
     CircularDependenciesValidator,
 )
@@ -25,6 +26,7 @@ from drift.validation.validators.core.max_dependency_depth_validator import (
 from drift.validation.validators.core.regex_validators import RegexMatchValidator
 
 __all__ = [
+    "BlockLineCountValidator",
     "CircularDependenciesValidator",
     "DependencyDuplicateValidator",
     "FileExistsValidator",

--- a/src/drift/validation/validators/core/block_validators.py
+++ b/src/drift/validation/validators/core/block_validators.py
@@ -1,0 +1,330 @@
+"""Validators for block-based content analysis."""
+
+import re
+from typing import List, Literal, Optional
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentRule
+from drift.validation.validators.base import BaseValidator
+
+
+class BlockLineCountValidator(BaseValidator):
+    """Validator for counting lines within paired delimiters.
+
+    Validates content within paired delimiters (code blocks, YAML sections, etc.)
+    against line count thresholds using comparison operators.
+
+    Configuration Parameters (via rule.params):
+        pattern_start: Regex pattern for opening delimiter (e.g., "^```")
+        pattern_end: Regex pattern for closing delimiter (e.g., "^```")
+        min_lines: Minimum lines required (inclusive, >=)
+        max_lines: Maximum lines allowed (inclusive, <=)
+        exact_lines: Exact line count required (==)
+        files: List of file patterns to validate (glob patterns)
+
+    Example usage in .drift.yaml:
+        - name: "Ensure code examples are substantial"
+          type: core:block_line_count
+          params:
+            pattern_start: "^```"
+            pattern_end: "^```"
+            min_lines: 3
+            files: ["README.md", "docs/**/*.md"]
+
+    Edge Cases Handled:
+        - Unpaired delimiters: Clear error messages
+        - Empty blocks: Counted as 0 lines
+        - Multiple paired blocks: All validated
+        - Line count excludes delimiter lines themselves
+    """
+
+    @property
+    def validation_type(self) -> str:
+        """Return validation type for this validator."""
+        return "core:block_line_count"
+
+    @property
+    def computation_type(self) -> Literal["programmatic", "llm"]:
+        """Return computation type for this validator."""
+        return "programmatic"
+
+    @property
+    def default_failure_message(self) -> str:
+        """Return default failure message template."""
+        return "Block line count validation failed"
+
+    @property
+    def default_expected_behavior(self) -> str:
+        """Return default expected behavior description."""
+        return "Blocks should meet line count constraints"
+
+    def validate(
+        self,
+        rule: ValidationRule,
+        bundle: DocumentBundle,
+        all_bundles: Optional[List[DocumentBundle]] = None,
+    ) -> Optional[DocumentRule]:
+        """Validate block line counts in files.
+
+        -- rule: ValidationRule with params containing patterns and thresholds
+        -- bundle: Document bundle being validated
+        -- all_bundles: Not used for this validator
+
+        Returns DocumentRule if validation fails, None if passes.
+        """
+        # Extract parameters from params dict
+        pattern_start = rule.params.get("pattern_start")
+        pattern_end = rule.params.get("pattern_end")
+        min_lines = rule.params.get("min_lines")
+        max_lines = rule.params.get("max_lines")
+        exact_lines = rule.params.get("exact_lines")
+        file_patterns = rule.params.get("files", [])
+
+        # Validate required parameters
+        if not pattern_start:
+            raise ValueError("BlockLineCountValidator requires params.pattern_start")
+        if not pattern_end:
+            raise ValueError("BlockLineCountValidator requires params.pattern_end")
+
+        # At least one threshold must be specified
+        if min_lines is None and max_lines is None and exact_lines is None:
+            raise ValueError(
+                "BlockLineCountValidator requires at least one of: "
+                "params.min_lines, params.max_lines, or params.exact_lines"
+            )
+
+        # Compile patterns
+        try:
+            start_re = re.compile(pattern_start, re.MULTILINE)
+            end_re = re.compile(pattern_end, re.MULTILINE)
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern: {e}")
+
+        # Get files to validate
+        if not file_patterns:
+            # No file patterns specified, use all files in bundle
+            files_to_check = bundle.files
+        else:
+            # Match files against patterns
+            files_to_check = []
+            for pattern in file_patterns:
+                import fnmatch
+
+                for doc_file in bundle.files:
+                    if fnmatch.fnmatch(doc_file.relative_path, pattern):
+                        if doc_file not in files_to_check:
+                            files_to_check.append(doc_file)
+
+        if not files_to_check:
+            # No files to check
+            return None
+
+        # Track violations
+        violations = []
+        total_blocks = 0
+
+        for doc_file in files_to_check:
+            file_path = bundle.project_path / doc_file.relative_path
+
+            # Read file content
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    lines = f.readlines()
+            except FileNotFoundError:
+                # File listed in bundle but doesn't exist - skip it
+                continue
+            except IsADirectoryError:
+                # File path points to a directory - skip it
+                continue
+            except (PermissionError, UnicodeDecodeError) as e:
+                # Can't read file due to permissions or encoding - return error
+                error_type = type(e).__name__
+                return DocumentRule(
+                    bundle_id=bundle.bundle_id,
+                    bundle_type=bundle.bundle_type,
+                    file_paths=[doc_file.relative_path],
+                    observed_issue=(f"Failed to read file {doc_file.relative_path}: {error_type}"),
+                    expected_quality=self._get_expected_behavior(rule),
+                    rule_type="",
+                    context=f"Validation rule: {rule.description}",
+                )
+
+            # Check if start and end patterns are the same
+            same_delimiter = pattern_start == pattern_end
+
+            if same_delimiter:
+                # When start/end are the same, treat alternating matches as open/close
+                matches = []
+                for i, line in enumerate(lines, start=1):
+                    if start_re.search(line):
+                        matches.append(i)
+
+                # Pair up alternating matches
+                if len(matches) % 2 != 0:
+                    return DocumentRule(
+                        bundle_id=bundle.bundle_id,
+                        bundle_type=bundle.bundle_type,
+                        file_paths=[doc_file.relative_path],
+                        observed_issue=(
+                            f"Unpaired delimiters in {doc_file.relative_path}: "
+                            f"odd number of delimiter matches ({len(matches)})"
+                        ),
+                        expected_quality=self._get_expected_behavior(rule),
+                        rule_type="",
+                        context=f"Validation rule: {rule.description}",
+                    )
+
+                # Pair them up: [0,1], [2,3], [4,5], ...
+                block_pairs = [(matches[i], matches[i + 1]) for i in range(0, len(matches), 2)]
+            else:
+                # Different start/end patterns - need to pair each start with next unpaired end
+                block_starts = []
+                block_ends = []
+
+                for i, line in enumerate(lines, start=1):
+                    if start_re.search(line):
+                        block_starts.append(i)
+                    # For end pattern, only match if it's NOT also a start
+                    # This handles cases like "^```yaml" (start) and "^```" (end)
+                    # where the end pattern is less specific
+                    elif end_re.search(line):
+                        block_ends.append(i)
+
+                # Pair each start with the next available end that comes after it
+                block_pairs = []
+                used_ends = set()
+
+                for start in block_starts:
+                    # Find next end after this start that hasn't been used
+                    paired = False
+                    for end in block_ends:
+                        if end > start and end not in used_ends:
+                            block_pairs.append((start, end))
+                            used_ends.add(end)
+                            paired = True
+                            break
+
+                    if not paired:
+                        # No available end for this start
+                        return DocumentRule(
+                            bundle_id=bundle.bundle_id,
+                            bundle_type=bundle.bundle_type,
+                            file_paths=[doc_file.relative_path],
+                            observed_issue=(
+                                f"Unpaired delimiters in {doc_file.relative_path}: "
+                                f"start at line {start} has no matching end"
+                            ),
+                            expected_quality=self._get_expected_behavior(rule),
+                            rule_type="",
+                            context=f"Validation rule: {rule.description}",
+                        )
+
+                # Check if there are unused ends
+                if len(used_ends) < len(block_ends):
+                    unused_ends = [e for e in block_ends if e not in used_ends]
+                    unused_str = ", ".join(map(str, unused_ends))
+                    return DocumentRule(
+                        bundle_id=bundle.bundle_id,
+                        bundle_type=bundle.bundle_type,
+                        file_paths=[doc_file.relative_path],
+                        observed_issue=(
+                            f"Unpaired delimiters in {doc_file.relative_path}: "
+                            f"unmatched end delimiter(s) at line(s): {unused_str}"
+                        ),
+                        expected_quality=self._get_expected_behavior(rule),
+                        rule_type="",
+                        context=f"Validation rule: {rule.description}",
+                    )
+
+            # Process each block
+            for start_line, end_line in block_pairs:
+                if end_line <= start_line:
+                    return DocumentRule(
+                        bundle_id=bundle.bundle_id,
+                        bundle_type=bundle.bundle_type,
+                        file_paths=[doc_file.relative_path],
+                        observed_issue=(
+                            f"Invalid block in {doc_file.relative_path}: "
+                            f"end line {end_line} before/at start line {start_line}"
+                        ),
+                        expected_quality=self._get_expected_behavior(rule),
+                        rule_type="",
+                        context=f"Validation rule: {rule.description}",
+                    )
+
+                # Count lines between delimiters (excluding delimiter lines)
+                line_count = end_line - start_line - 1
+                total_blocks += 1
+
+                # Check against thresholds
+                threshold_violated = False
+                threshold_desc = ""
+
+                if exact_lines is not None:
+                    if line_count != exact_lines:
+                        threshold_violated = True
+                        threshold_desc = f"expected exactly {exact_lines}"
+                elif min_lines is not None and line_count < min_lines:
+                    threshold_violated = True
+                    threshold_desc = f"expected at least {min_lines}"
+                elif max_lines is not None and line_count > max_lines:
+                    threshold_violated = True
+                    threshold_desc = f"expected at most {max_lines}"
+
+                if threshold_violated:
+                    violations.append(
+                        {
+                            "file_path": doc_file.relative_path,
+                            "line_start": start_line,
+                            "line_end": end_line,
+                            "actual_count": line_count,
+                            "threshold": threshold_desc,
+                        }
+                    )
+
+        if not violations:
+            # All blocks passed
+            return None
+
+        # Build failure message
+        threshold_label = ""
+        if exact_lines is not None:
+            threshold_label = f"exact {exact_lines}"
+        elif min_lines is not None:
+            threshold_label = f"min {min_lines}"
+        elif max_lines is not None:
+            threshold_label = f"max {max_lines}"
+
+        # Create detailed failure message
+        failure_lines = [
+            f"Found {total_blocks} total blocks, {len(violations)} in violation",
+            f"Threshold: {threshold_label}",
+            "",
+        ]
+
+        for v in violations:
+            failure_lines.append(
+                f"{v['file_path']}:{v['line_start']}-{v['line_end']}: "
+                f"{v['actual_count']} lines ({v['threshold']})"
+            )
+
+        failure_details = {
+            "total_blocks": total_blocks,
+            "violations_count": len(violations),
+            "threshold": threshold_label,
+            "violations": violations,
+        }
+
+        # Extract unique file paths
+        file_paths = sorted({str(v["file_path"]) for v in violations})
+
+        return DocumentRule(
+            bundle_id=bundle.bundle_id,
+            bundle_type=bundle.bundle_type,
+            file_paths=file_paths,
+            observed_issue="\n   ".join(failure_lines),
+            expected_quality=self._get_expected_behavior(rule),
+            rule_type="",  # Will be set by analyzer
+            context=f"Validation rule: {rule.description}",
+            failure_details=failure_details,
+        )

--- a/src/drift/validation/validators/core/format_validators.py
+++ b/src/drift/validation/validators/core/format_validators.py
@@ -43,32 +43,37 @@ class JsonSchemaValidator(BaseValidator):
     ) -> Optional[DocumentRule]:
         """Validate JSON file against schema.
 
-        Schema can be provided via:
-        - rule.params['schema']: Inline schema dict
-        - rule.params['schema_file']: Path to schema file (relative to project)
+        Expected params:
+            - file_path: File path to validate (required)
+            - schema: Inline schema dict (required if no schema_file)
+            - schema_file: Path to schema file (required if no schema)
 
-        -- rule: ValidationRule with file_path and schema
+        -- rule: ValidationRule with params containing file_path and schema
         -- bundle: Document bundle being validated
         -- all_bundles: Not used for this validator
 
         Returns DocumentRule if validation fails, None if passes.
         """
-        if not rule.file_path:
-            raise ValueError("JsonSchemaValidator requires rule.file_path")
+        if not rule.params:
+            raise ValueError("JsonSchemaValidator requires params")
+
+        file_path_str = rule.params.get("file_path")
+        if not file_path_str:
+            raise ValueError("JsonSchemaValidator requires params.file_path")
 
         if not rule.params:
             raise ValueError("JsonSchemaValidator requires params with 'schema' or 'schema_file'")
 
         project_path = bundle.project_path
-        file_path = project_path / rule.file_path
+        file_path = project_path / file_path_str
 
         # Check if file exists
         if not file_path.exists() or not file_path.is_file():
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
-                observed_issue=f"File {rule.file_path} does not exist",
+                file_paths=[file_path_str],
+                observed_issue=f"File {file_path_str} does not exist",
             )
 
         # Load JSON data
@@ -79,14 +84,14 @@ class JsonSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Invalid JSON: {e}",
             )
         except Exception as e:
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Failed to read file: {e}",
             )
 
@@ -96,7 +101,7 @@ class JsonSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=schema,
             )
 
@@ -107,7 +112,7 @@ class JsonSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=(
                     "JSON Schema validation requires 'jsonschema' package. "
                     "Install with: pip install jsonschema"
@@ -123,14 +128,14 @@ class JsonSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Schema validation failed at {path}: {e.message}",
             )
         except jsonschema.SchemaError as e:
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Invalid schema: {e.message}",
             )
 
@@ -213,32 +218,37 @@ class YamlSchemaValidator(BaseValidator):
     ) -> Optional[DocumentRule]:
         """Validate YAML file against schema.
 
-        Schema can be provided via:
-        - rule.params['schema']: Inline schema dict
-        - rule.params['schema_file']: Path to schema file (relative to project)
+        Expected params:
+            - file_path: File path to validate (required)
+            - schema: Inline schema dict (required if no schema_file)
+            - schema_file: Path to schema file (required if no schema)
 
-        -- rule: ValidationRule with file_path and schema
+        -- rule: ValidationRule with params containing file_path and schema
         -- bundle: Document bundle being validated
         -- all_bundles: Not used for this validator
 
         Returns DocumentRule if validation fails, None if passes.
         """
-        if not rule.file_path:
-            raise ValueError("YamlSchemaValidator requires rule.file_path")
+        if not rule.params:
+            raise ValueError("YamlSchemaValidator requires params")
+
+        file_path_str = rule.params.get("file_path")
+        if not file_path_str:
+            raise ValueError("YamlSchemaValidator requires params.file_path")
 
         if not rule.params:
             raise ValueError("YamlSchemaValidator requires params with 'schema' or 'schema_file'")
 
         project_path = bundle.project_path
-        file_path = project_path / rule.file_path
+        file_path = project_path / file_path_str
 
         # Check if file exists
         if not file_path.exists() or not file_path.is_file():
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
-                observed_issue=f"File {rule.file_path} does not exist",
+                file_paths=[file_path_str],
+                observed_issue=f"File {file_path_str} does not exist",
             )
 
         # Load YAML data
@@ -248,7 +258,7 @@ class YamlSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=(
                     "YAML validation requires 'pyyaml' package. " "Install with: pip install pyyaml"
                 ),
@@ -261,14 +271,14 @@ class YamlSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Invalid YAML: {e}",
             )
         except Exception as e:
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Failed to read file: {e}",
             )
 
@@ -278,7 +288,7 @@ class YamlSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=schema,
             )
 
@@ -289,7 +299,7 @@ class YamlSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=(
                     "YAML Schema validation requires 'jsonschema' package. "
                     "Install with: pip install jsonschema"
@@ -305,14 +315,14 @@ class YamlSchemaValidator(BaseValidator):
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Schema validation failed at {path}: {e.message}",
             )
         except jsonschema.SchemaError as e:
             return self._create_failure(
                 rule=rule,
                 bundle=bundle,
-                file_paths=[rule.file_path],
+                file_paths=[file_path_str],
                 observed_issue=f"Invalid schema: {e.message}",
             )
 

--- a/tests/integration/test_rule_validation.py
+++ b/tests/integration/test_rule_validation.py
@@ -78,7 +78,7 @@ class TestRuleBasedValidation:
                 PhaseDefinition(
                     name="check_file",
                     type="core:file_exists",
-                    file_path="CLAUDE.md",
+                    params={"file_path": "CLAUDE.md"},
                     failure_message="CLAUDE.md not found",
                     expected_behavior="CLAUDE.md should exist",
                 )
@@ -113,7 +113,7 @@ class TestRuleBasedValidation:
                 PhaseDefinition(
                     name="check_file",
                     type="core:file_exists",
-                    file_path="MISSING.md",
+                    params={"file_path": "MISSING.md"},
                     failure_message="MISSING.md not found",
                     expected_behavior="MISSING.md should exist",
                 )
@@ -156,7 +156,7 @@ class TestRuleBasedValidation:
                     ValidationRule(
                         rule_type="core:file_not_exists",
                         description="CLAUDE.md must not exist",
-                        file_path="CLAUDE.md",
+                        params={"file_path": "CLAUDE.md"},
                         failure_message="CLAUDE.md exists but should not",
                         expected_behavior="CLAUDE.md should be absent",
                     )
@@ -198,7 +198,7 @@ class TestRuleBasedValidation:
                     ValidationRule(
                         rule_type="core:file_exists",
                         description="At least one skill must exist",
-                        file_path=".claude/skills/*/SKILL.md",
+                        params={"file_path": ".claude/skills/*/SKILL.md"},
                         failure_message="No skill files found",
                         expected_behavior="At least one SKILL.md should exist",
                     )
@@ -236,21 +236,21 @@ class TestRuleBasedValidation:
                     ValidationRule(
                         rule_type="core:file_exists",
                         description="README must exist",
-                        file_path="README.md",
+                        params={"file_path": "README.md"},
                         failure_message="README.md not found",
                         expected_behavior="README.md should exist",
                     ),
                     ValidationRule(
                         rule_type="core:file_exists",
                         description="CLAUDE must exist",
-                        file_path="CLAUDE.md",
+                        params={"file_path": "CLAUDE.md"},
                         failure_message="CLAUDE.md not found",
                         expected_behavior="CLAUDE.md should exist",
                     ),
                     ValidationRule(
                         rule_type="core:file_exists",
                         description="MISSING check (will fail)",
-                        file_path="MISSING.md",
+                        params={"file_path": "MISSING.md"},
                         failure_message="MISSING.md not found",
                         expected_behavior="MISSING.md should exist",
                     ),

--- a/tests/unit/test_block_line_count_validator.py
+++ b/tests/unit/test_block_line_count_validator.py
@@ -1,0 +1,1084 @@
+"""Tests for BlockLineCountValidator."""
+
+import pytest
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentFile
+from drift.validation.validators.core.block_validators import BlockLineCountValidator
+
+
+class TestBlockLineCountValidator:
+    """Tests for BlockLineCountValidator."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return BlockLineCountValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    @pytest.fixture
+    def bundle_with_code_blocks(self, tmp_path):
+        """Create bundle with markdown file containing code blocks."""
+        content = """# README
+
+Some intro text.
+
+```python
+print("Hello")
+```
+
+More text.
+
+```python
+def foo():
+    pass
+```
+
+Even more text.
+
+```
+x = 1
+y = 2
+z = 3
+```
+
+End.
+"""
+        test_file = tmp_path / "README.md"
+        test_file.write_text(content)
+
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="README.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+    def test_validation_type(self, validator):
+        """Test validation_type property."""
+        assert validator.validation_type == "core:block_line_count"
+
+    def test_computation_type(self, validator):
+        """Test computation_type property."""
+        assert validator.computation_type == "programmatic"
+
+    def test_min_lines_pass(self, validator, bundle_with_code_blocks):
+        """Test that validation passes when all blocks meet minimum line count."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have at least 1 line",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["README.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_code_blocks)
+        assert result is None
+
+    def test_min_lines_fail(self, validator, bundle_with_code_blocks):
+        """Test that validation fails when blocks don't meet minimum."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have at least 3 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 3,
+                "files": ["README.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_code_blocks)
+        assert result is not None
+        assert "README.md" in result.file_paths
+        assert "Found 3 total blocks, 2 in violation" in result.observed_issue
+        assert "expected at least 3" in result.observed_issue
+
+    def test_max_lines_pass(self, validator, bundle_with_code_blocks):
+        """Test that validation passes when all blocks are under maximum."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should not exceed 10 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "max_lines": 10,
+                "files": ["README.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_code_blocks)
+        assert result is None
+
+    def test_max_lines_fail(self, validator, bundle_with_code_blocks):
+        """Test that validation fails when blocks exceed maximum."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should not exceed 2 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "max_lines": 2,
+                "files": ["README.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_code_blocks)
+        assert result is not None
+        assert "README.md" in result.file_paths
+        assert "Found 3 total blocks, 1 in violation" in result.observed_issue
+        assert "expected at most 2" in result.observed_issue
+
+    def test_exact_lines_pass(self, validator, tmp_path):
+        """Test that validation passes when blocks have exact line count."""
+        content = """# Test
+
+```
+line1
+line2
+```
+
+```
+line1
+line2
+```
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have exactly 2 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "exact_lines": 2,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_exact_lines_fail(self, validator, bundle_with_code_blocks):
+        """Test that validation fails when blocks don't have exact line count."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have exactly 2 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "exact_lines": 2,
+                "files": ["README.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_code_blocks)
+        assert result is not None
+        assert "README.md" in result.file_paths
+        assert "Found 3 total blocks, 2 in violation" in result.observed_issue
+        assert "expected exactly 2" in result.observed_issue
+
+    def test_empty_blocks(self, validator, tmp_path):
+        """Test handling of empty blocks (0 lines between delimiters)."""
+        content = """# Test
+
+```
+```
+
+```
+content
+```
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have at least 1 line",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Found 2 total blocks, 1 in violation" in result.observed_issue
+        assert "0 lines (expected at least 1)" in result.observed_issue
+
+    def test_unpaired_delimiters_too_many_opens(self, validator, tmp_path):
+        """Test error handling for unpaired delimiters (more opens than closes)."""
+        content = """# Test
+
+```
+content
+```
+
+```
+orphaned
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Unpaired delimiters" in result.observed_issue
+        assert "test.md" in result.file_paths
+
+    def test_unpaired_delimiters_too_many_closes(self, validator, tmp_path):
+        """Test error handling for unpaired delimiters (more closes than opens)."""
+        content = """# Test
+
+```
+content
+```
+
+```
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Unpaired delimiters" in result.observed_issue
+
+    def test_multiple_files(self, validator, tmp_path):
+        """Test validation across multiple files."""
+        content1 = """```
+line1
+line2
+```"""
+        content2 = """```
+x
+```"""
+
+        file1 = tmp_path / "file1.md"
+        file1.write_text(content1)
+        file2 = tmp_path / "file2.md"
+        file2.write_text(content2)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="collection",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="file1.md",
+                    content=content1,
+                    file_path=str(file1),
+                ),
+                DocumentFile(
+                    relative_path="file2.md",
+                    content=content2,
+                    file_path=str(file2),
+                ),
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have at least 2 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 2,
+                "files": ["*.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Found 2 total blocks, 1 in violation" in result.observed_issue
+        assert "file2.md" in result.observed_issue
+
+    def test_yaml_blocks(self, validator, tmp_path):
+        """Test validation of YAML code blocks."""
+        content = """# Config
+
+```yaml
+key: value
+another: value
+third: value
+```
+
+```yaml
+short: value
+```
+"""
+        test_file = tmp_path / "config.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="config.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="YAML blocks should not exceed 2 lines",
+            params={
+                "pattern_start": "^```yaml",
+                "pattern_end": "^```",
+                "max_lines": 2,
+                "files": ["config.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Found 2 total blocks, 1 in violation" in result.observed_issue
+        assert "expected at most 2" in result.observed_issue
+
+    def test_no_files_match_pattern(self, validator, tmp_path):
+        """Test that validation passes when no files match the pattern."""
+        content = "No code blocks here"
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["nonexistent.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_no_blocks_in_file(self, validator, tmp_path):
+        """Test that validation passes when file has no matching blocks."""
+        content = "Just plain text, no code blocks"
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_missing_pattern_start(self, validator, tmp_path):
+        """Test that validator raises error when pattern_start is missing."""
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Missing pattern_start",
+            params={
+                "pattern_end": "^```",
+                "min_lines": 1,
+            },
+        )
+
+        with pytest.raises(ValueError, match="requires params.pattern_start"):
+            validator.validate(rule, bundle)
+
+    def test_missing_pattern_end(self, validator, tmp_path):
+        """Test that validator raises error when pattern_end is missing."""
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Missing pattern_end",
+            params={
+                "pattern_start": "^```",
+                "min_lines": 1,
+            },
+        )
+
+        with pytest.raises(ValueError, match="requires params.pattern_end"):
+            validator.validate(rule, bundle)
+
+    def test_missing_threshold(self, validator, tmp_path):
+        """Test that validator raises error when no threshold is specified."""
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="No threshold",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+            },
+        )
+
+        with pytest.raises(
+            ValueError, match="requires at least one of: params.min_lines, params.max_lines"
+        ):
+            validator.validate(rule, bundle)
+
+    def test_invalid_regex_pattern(self, validator, tmp_path):
+        """Test that validator raises error for invalid regex patterns."""
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Invalid regex",
+            params={
+                "pattern_start": "[invalid(regex",
+                "pattern_end": "^```",
+                "min_lines": 1,
+            },
+        )
+
+        with pytest.raises(ValueError, match="Invalid regex pattern"):
+            validator.validate(rule, bundle)
+
+    def test_file_read_error(self, validator, tmp_path):
+        """Test handling of file read errors."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("content")
+        test_file.chmod(0o000)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content="",
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        try:
+            result = validator.validate(rule, bundle)
+            assert result is not None
+            assert "Failed to read file" in result.observed_issue
+        finally:
+            test_file.chmod(0o644)
+
+    def test_combined_min_max_thresholds(self, validator, tmp_path):
+        """Test validation with both min and max thresholds."""
+        content = """```
+line1
+```
+
+```
+line1
+line2
+line3
+```
+
+```
+line1
+line2
+```
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have 2-3 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 2,
+                "max_lines": 3,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Found 3 total blocks, 1 in violation" in result.observed_issue
+        assert "1 lines (expected at least 2)" in result.observed_issue
+
+    def test_line_range_in_violation_message(self, validator, tmp_path):
+        """Test that violation messages include correct line ranges."""
+        content = """Line 1
+Line 2
+```
+Line 4
+```
+Line 6
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have at least 2 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 2,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "test.md:3-5" in result.observed_issue
+        assert "1 lines" in result.observed_issue
+
+    def test_failure_details_populated(self, validator, bundle_with_code_blocks):
+        """Test that failure_details is properly populated for failures."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have at least 3 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 3,
+                "files": ["README.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_code_blocks)
+        assert result is not None
+        assert result.failure_details is not None
+        assert "total_blocks" in result.failure_details
+        assert result.failure_details["total_blocks"] == 3
+        assert "violations" in result.failure_details
+        assert len(result.failure_details["violations"]) == 2
+        assert "threshold" in result.failure_details
+
+    def test_no_file_patterns_validates_all_bundle_files(self, validator, tmp_path):
+        """Test that when no file patterns are specified, all bundle files are validated."""
+        content = """```
+line1
+```"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Code blocks should have at least 2 lines",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 2,
+                # No files parameter - should validate all files in bundle
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "test.md" in result.observed_issue
+
+    def test_different_start_end_delimiters(self, validator, tmp_path):
+        """Test validation with different start and end delimiters."""
+        content = """# Test
+
+<block>
+line1
+line2
+</block>
+
+<block>
+x
+</block>
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Blocks should have at least 2 lines",
+            params={
+                "pattern_start": "^<block>",
+                "pattern_end": "^</block>",
+                "min_lines": 2,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Found 2 total blocks, 1 in violation" in result.observed_issue
+
+    def test_different_delimiters_end_before_start(self, validator, tmp_path):
+        """Test error handling when end delimiter comes before start."""
+        content = """</block>
+<block>
+content
+</block>
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^<block>",
+                "pattern_end": "^</block>",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Unpaired delimiters" in result.observed_issue
+
+    def test_file_not_exist_in_pattern_list(self, validator, tmp_path):
+        """Test that non-existent files in glob patterns are skipped gracefully."""
+        content = """```
+content
+```"""
+        test_file = tmp_path / "exists.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="exists.md",
+                    content=content,
+                    file_path=str(test_file),
+                ),
+                DocumentFile(
+                    relative_path="missing.md",
+                    content="",
+                    file_path=str(tmp_path / "missing.md"),
+                ),
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["*.md"],
+            },
+        )
+
+        # Should validate only the existing file
+        result = validator.validate(rule, bundle)
+        assert result is None  # exists.md has 1 line which meets min_lines
+
+    def test_file_exists_but_is_directory(self, validator, tmp_path):
+        """Test that directories in bundle files are skipped gracefully."""
+        content = """```
+content
+```"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        # Create a directory with same name as potential file
+        dir_path = tmp_path / "subdir"
+        dir_path.mkdir()
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                ),
+                DocumentFile(
+                    relative_path="subdir",
+                    content="",
+                    file_path=str(dir_path),
+                ),
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                # No files parameter - will use all files in bundle including the directory
+            },
+        )
+
+        # Should validate only the file, skip the directory
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_different_delimiters_interleaved_wrong_order(self, validator, tmp_path):
+        """Test when delimiters are interleaved in wrong order (end before corresponding start)."""
+        # Create content where we have equal numbers but ends come before starts
+        # Line 0: </end>     -> end_indices = [0]
+        # Line 1: <start>    -> start_indices = [1]
+        # When zipped: (1, 0) means start at line 1, end at line 0
+        # This triggers end_idx <= start_idx check at line 268
+        content = """</end>
+<start>
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^<start>",
+                "pattern_end": "^</end>",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        # Should detect unpaired delimiters (end comes before start)
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Unpaired delimiters" in result.observed_issue
+
+    def test_same_delimiters_end_before_start(self, validator, tmp_path):
+        """Test error when end_line <= start_line for same delimiters."""
+        # This is a special case where we manually create a scenario
+        # where end_line could be <= start_line (line 242)
+        # For same delimiters, this can only happen if delimiters are on same line
+        # which is impossible with our pairing logic. However, we can test
+        # the edge case by ensuring consecutive delimiters work properly.
+        content = """```
+```
+```
+content
+```"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        # Should validate the empty block and the block with content
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "0 lines" in result.observed_issue
+
+    def test_default_failure_message(self, validator):
+        """Test default_failure_message property."""
+        assert validator.default_failure_message == "Block line count validation failed"
+
+    def test_unicode_decode_error(self, validator, tmp_path):
+        """Test handling of files with encoding errors."""
+        # Create a file with invalid UTF-8
+        test_file = tmp_path / "binary.md"
+        test_file.write_bytes(b"\x80\x81\x82\x83")
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="binary.md",
+                    content="",
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["binary.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "Failed to read file" in result.observed_issue
+        assert "UnicodeDecodeError" in result.observed_issue

--- a/tests/unit/test_file_exists_validator_bug_43.py
+++ b/tests/unit/test_file_exists_validator_bug_43.py
@@ -51,7 +51,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check skill filename consistency",
-            file_path=".claude/skills/*/SKILL.md",
+            params={"file_path": ".claude/skills/*/SKILL.md"},
             failure_message="Skill files should be named SKILL.md (uppercase), not skill.md",
             expected_behavior="All skill files should use SKILL.md naming convention",
         )
@@ -83,7 +83,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check skill filename consistency",
-            file_path=".claude/skills/*/SKILL.md",
+            params={"file_path": ".claude/skills/*/SKILL.md"},
             failure_message="Skill files should be named SKILL.md (uppercase), not skill.md",
             expected_behavior="All skill files should use SKILL.md naming convention",
         )
@@ -118,7 +118,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check skill filename consistency",
-            file_path=".claude/skills/*/SKILL.md",
+            params={"file_path": ".claude/skills/*/SKILL.md"},
             failure_message="Skill files should be named SKILL.md (uppercase), not skill.md",
             expected_behavior="All skill files should use SKILL.md naming convention",
         )
@@ -151,7 +151,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check skill filename consistency",
-            file_path=".claude/skills/*/SKILL.md",
+            params={"file_path": ".claude/skills/*/SKILL.md"},
             failure_message="Skill files should be named SKILL.md",
             expected_behavior="All skill files should use SKILL.md naming convention",
         )
@@ -187,7 +187,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check skill filename consistency",
-            file_path=".claude/skills/*/SKILL.md",
+            params={"file_path": ".claude/skills/*/SKILL.md"},
             failure_message="Skill files should be named SKILL.md (uppercase), not skill.md",
             expected_behavior="All skill files should use SKILL.md naming convention",
         )
@@ -213,7 +213,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check files with single char wildcard",
-            file_path="test?.md",
+            params={"file_path": "test?.md"},
             failure_message="No test files found",
             expected_behavior="Test files should exist",
         )
@@ -240,7 +240,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check for markdown files",
-            file_path="docs/*.md",
+            params={"file_path": "docs/*.md"},
             failure_message="No markdown files found in docs/",
             expected_behavior="Markdown files should exist in docs/",
         )
@@ -261,7 +261,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check nested pattern",
-            file_path="a/b/c/*.md",
+            params={"file_path": "a/b/c/*.md"},
             failure_message="No nested files found",
             expected_behavior="Nested files should exist",
         )
@@ -283,7 +283,7 @@ class TestFileExistsValidatorGlobPatterns:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check multiple wildcards",
-            file_path=".claude/*/*.md",
+            params={"file_path": ".claude/*/*.md"},
             failure_message="No claude config files found",
             expected_behavior="Claude config files should exist",
         )
@@ -332,7 +332,7 @@ class TestFileExistsValidatorEdgeCases:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check for skill dirs",
-            file_path=".claude/skills/*",
+            params={"file_path": ".claude/skills/*"},
             failure_message="No skills found",
             expected_behavior="Skills should exist",
         )
@@ -362,7 +362,7 @@ class TestFileExistsValidatorEdgeCases:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check symlink file",
-            file_path="link.md",
+            params={"file_path": "link.md"},
             failure_message="Symlink not found",
             expected_behavior="Symlink should exist",
         )
@@ -383,7 +383,7 @@ class TestFileExistsValidatorEdgeCases:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check README",
-            file_path="README.md",
+            params={"file_path": "README.md"},
             failure_message="README not found",
             expected_behavior="README should exist",
         )

--- a/tests/unit/test_file_size_validator.py
+++ b/tests/unit/test_file_size_validator.py
@@ -65,8 +65,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check CLAUDE.md line count",
-            file_path="CLAUDE.md",
-            max_count=300,
+            params={"file_path": "CLAUDE.md", "max_count": 300},
             failure_message="CLAUDE.md exceeds 300 lines",
             expected_behavior="CLAUDE.md should be under 300 lines",
         )
@@ -98,8 +97,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check CLAUDE.md line count",
-            file_path="CLAUDE.md",
-            max_count=300,
+            params={"file_path": "CLAUDE.md", "max_count": 300},
             failure_message="CLAUDE.md exceeds 300 lines",
             expected_behavior="CLAUDE.md should be under 300 lines",
         )
@@ -134,8 +132,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check line count",
-            file_path="test.md",
-            max_count=300,
+            params={"file_path": "test.md", "max_count": 300},
             failure_message="File too large",
             expected_behavior="File should be under 300 lines",
         )
@@ -167,8 +164,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check minimum line count",
-            file_path="test.md",
-            min_count=10,
+            params={"file_path": "test.md", "min_count": 10},
             failure_message="File too small",
             expected_behavior="File should have at least 10 lines",
         )
@@ -202,8 +198,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check byte size",
-            file_path="test.txt",
-            max_size=1000,
+            params={"file_path": "test.txt", "max_size": 1000},
             failure_message="File too large",
             expected_behavior="File should be under 1000 bytes",
         )
@@ -237,8 +232,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check byte size",
-            file_path="test.txt",
-            max_size=1000,
+            params={"file_path": "test.txt", "max_size": 1000},
             failure_message="File too large",
             expected_behavior="File should be under 1000 bytes",
         )
@@ -251,8 +245,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check nonexistent file",
-            file_path="nonexistent.md",
-            max_count=100,
+            params={"file_path": "nonexistent.md", "max_count": 100},
             failure_message="File not found",
             expected_behavior="File should exist",
         )
@@ -272,7 +265,7 @@ class TestFileSizeValidator:
             expected_behavior="Should error",
         )
 
-        with pytest.raises(ValueError, match="requires rule.file_path"):
+        with pytest.raises(ValueError, match="requires params"):
             validator.validate(rule, bundle_with_file)
 
     def test_no_constraints(self, validator, bundle_with_file):
@@ -280,7 +273,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="No constraints",
-            file_path="test.md",
+            params={"file_path": "test.md"},
             failure_message="Error",
             expected_behavior="Should pass",
         )
@@ -312,8 +305,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check both constraints",
-            file_path="test.md",
-            max_count=100,
+            params={"file_path": "test.md", "max_count": 100},
             max_size=1000,
             failure_message="File violates constraints",
             expected_behavior="File should meet all constraints",
@@ -349,8 +341,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check empty file",
-            file_path="empty.md",
-            max_count=100,
+            params={"file_path": "empty.md", "max_count": 100},
             max_size=1000,
             failure_message="File too large",
             expected_behavior="File should be small",
@@ -381,8 +372,7 @@ class TestFileSizeValidator:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Check single line",
-            file_path="single.md",
-            max_count=10,
+            params={"file_path": "single.md", "max_count": 10},
             failure_message="File too large",
             expected_behavior="File should be under 10 lines",
         )

--- a/tests/unit/test_json_schema_validator.py
+++ b/tests/unit/test_json_schema_validator.py
@@ -68,8 +68,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate data.json",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Invalid JSON structure",
             expected_behavior="Should match schema",
         )
@@ -99,8 +98,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate data.json",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Invalid JSON structure",
             expected_behavior="Should match schema",
         )
@@ -131,8 +129,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate data.json",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Invalid JSON structure",
             expected_behavior="Should match schema",
         )
@@ -169,8 +166,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate data.json",
-            file_path="data.json",
-            params={"schema_file": "schema.json"},
+            params={"file_path": "data.json", "schema_file": "schema.json"},
             failure_message="Invalid JSON structure",
             expected_behavior="Should match schema",
         )
@@ -183,8 +179,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate config.json",
-            file_path="config.json",
-            params={"schema_file": "nonexistent_schema.json"},
+            params={"file_path": "config.json", "schema_file": "nonexistent_schema.json"},
             failure_message="Invalid JSON structure",
             expected_behavior="Should match schema",
         )
@@ -212,8 +207,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate data.json",
-            file_path="data.json",
-            params={"schema_file": "bad_schema.json"},
+            params={"file_path": "data.json", "schema_file": "bad_schema.json"},
             failure_message="Invalid JSON structure",
             expected_behavior="Should match schema",
         )
@@ -234,29 +228,29 @@ class TestJsonSchemaValidator:
             expected_behavior="Should error",
         )
 
-        with pytest.raises(ValueError, match="requires rule.file_path"):
+        with pytest.raises(ValueError, match="requires params.file_path"):
             validator.validate(rule, bundle_with_json)
 
     def test_missing_params(self, validator, bundle_with_json):
-        """Test that validator raises error when params is missing."""
+        """Test that validation fails when schema/schema_file is missing."""
         rule = ValidationRule(
             rule_type="core:json_schema",
-            description="No params",
-            file_path="config.json",
+            description="No schema",
+            params={"file_path": "config.json"},
             failure_message="Error",
             expected_behavior="Should error",
         )
 
-        with pytest.raises(ValueError, match="requires params"):
-            validator.validate(rule, bundle_with_json)
+        result = validator.validate(rule, bundle_with_json)
+        assert result is not None
+        assert "requires 'schema' or 'schema_file'" in result.observed_issue
 
     def test_missing_schema_and_schema_file(self, validator, bundle_with_json):
         """Test that validation fails when neither schema nor schema_file provided."""
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="No schema",
-            file_path="config.json",
-            params={"other_param": "value"},
+            params={"file_path": "config.json", "other_param": "value"},
             failure_message="Error",
             expected_behavior="Should error",
         )
@@ -270,8 +264,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Check nonexistent file",
-            file_path="nonexistent.json",
-            params={"schema": {"type": "object"}},
+            params={"file_path": "nonexistent.json", "schema": {"type": "object"}},
             failure_message="File not found",
             expected_behavior="File should exist",
         )
@@ -296,8 +289,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate bad JSON",
-            file_path="bad.json",
-            params={"schema": {"type": "object"}},
+            params={"file_path": "bad.json", "schema": {"type": "object"}},
             failure_message="Invalid JSON",
             expected_behavior="Should be valid JSON",
         )
@@ -322,8 +314,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate JSON",
-            file_path="data.json",
-            params={"schema": {"type": "object"}},
+            params={"file_path": "data.json", "schema": {"type": "object"}},
             failure_message="Error",
             expected_behavior="Should validate",
         )
@@ -377,8 +368,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate nested structure",
-            file_path="nested.json",
-            params={"schema": schema},
+            params={"file_path": "nested.json", "schema": schema},
             failure_message="Invalid structure",
             expected_behavior="Should match nested schema",
         )
@@ -417,8 +407,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate array",
-            file_path="array.json",
-            params={"schema": schema},
+            params={"file_path": "array.json", "schema": schema},
             failure_message="Invalid array structure",
             expected_behavior="Should match array schema",
         )
@@ -447,8 +436,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate enum",
-            file_path="enum.json",
-            params={"schema": schema},
+            params={"file_path": "enum.json", "schema": schema},
             failure_message="Invalid status",
             expected_behavior="Status should be valid enum value",
         )
@@ -477,8 +465,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate enum",
-            file_path="enum.json",
-            params={"schema": schema},
+            params={"file_path": "enum.json", "schema": schema},
             failure_message="Invalid status",
             expected_behavior="Status should be valid enum value",
         )
@@ -508,8 +495,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate empty object",
-            file_path="empty.json",
-            params={"schema": schema},
+            params={"file_path": "empty.json", "schema": schema},
             failure_message="Invalid JSON",
             expected_behavior="Should be valid empty object",
         )
@@ -538,8 +524,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate with extra properties",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Invalid JSON",
             expected_behavior="Should allow additional properties",
         )
@@ -569,8 +554,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate strict schema",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Invalid JSON",
             expected_behavior="Should not allow additional properties",
         )
@@ -608,8 +592,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Test rule",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -640,8 +623,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Test rule",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -680,8 +662,7 @@ class TestJsonSchemaValidator:
         _ = ValidationRule(
             rule_type="core:json_schema",
             description="Test rule",
-            file_path="data.json",
-            params={"schema_file": "schema.json"},
+            params={"file_path": "data.json", "schema_file": "schema.json"},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -708,8 +689,7 @@ class TestJsonSchemaValidator:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Test rule",
-            file_path="data.json",
-            params={"schema": schema},
+            params={"file_path": "data.json", "schema": schema},
             failure_message="Failure",
             expected_behavior="Expected",
         )

--- a/tests/unit/test_plugin_registry.py
+++ b/tests/unit/test_plugin_registry.py
@@ -453,7 +453,7 @@ class TestBuiltinValidatorMigration:
     """Tests that all built-in validators use core: prefix."""
 
     def test_all_builtin_validators_registered(self):
-        """Test that all 19 core validators are registered with core: prefix."""
+        """Test that all 20 core validators are registered with core: prefix."""
         registry = ValidatorRegistry()
 
         expected_core_validators = [
@@ -467,6 +467,7 @@ class TestBuiltinValidatorMigration:
             "core:list_match",
             "core:list_regex_match",
             "core:markdown_link",
+            "core:block_line_count",
             "core:dependency_duplicate",
             "core:circular_dependencies",
             "core:max_dependency_depth",

--- a/tests/unit/test_regex_match_validator.py
+++ b/tests/unit/test_regex_match_validator.py
@@ -47,8 +47,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check for Prerequisites section",
-            file_path="test.md",
-            pattern=r"## Prerequisites",
+            params={"file_path": "test.md", "pattern": r"## Prerequisites"},
             failure_message="Missing Prerequisites section",
             expected_behavior="Should have Prerequisites section",
         )
@@ -61,8 +60,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check for Installation section",
-            file_path="test.md",
-            pattern=r"## Installation",
+            params={"file_path": "test.md", "pattern": r"## Installation"},
             failure_message="Missing Installation section",
             expected_behavior="Should have Installation section",
         )
@@ -94,9 +92,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Match line start",
-            file_path="test.txt",
-            pattern=r"^Second",
-            flags=re.MULTILINE,
+            params={"file_path": "test.txt", "pattern": r"^Second", "flags": re.MULTILINE},
             failure_message="Pattern not found",
             expected_behavior="Should match",
         )
@@ -109,8 +105,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check nonexistent file",
-            file_path="nonexistent.md",
-            pattern=r"test",
+            params={"file_path": "nonexistent.md", "pattern": r"test"},
             failure_message="File not found",
             expected_behavior="File should exist",
         )
@@ -125,7 +120,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check all files in bundle",
-            pattern=r"## Prerequisites",
+            params={"pattern": r"## Prerequisites"},
             failure_message="Missing Prerequisites section",
             expected_behavior="Should have Prerequisites section",
         )
@@ -147,7 +142,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check empty bundle",
-            pattern=r"test",
+            params={"pattern": r"test"},
             failure_message="Pattern not found",
             expected_behavior="Should match",
         )
@@ -185,7 +180,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check for Prerequisites in all files",
-            pattern=r"## Prerequisites",
+            params={"pattern": r"## Prerequisites"},
             failure_message="Missing Prerequisites section",
             expected_behavior="All files should have Prerequisites section",
         )
@@ -201,28 +196,26 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="No pattern",
-            file_path="test.md",
+            params={"file_path": "test.md"},
             failure_message="Error",
             expected_behavior="Should error",
         )
 
-        with pytest.raises(ValueError, match="requires rule.pattern"):
+        with pytest.raises(ValueError, match="requires params.pattern"):
             validator.validate(rule, bundle_with_file)
 
     def test_regex_match_invalid_pattern(self, validator, bundle_with_file):
-        """Test that ValidationRule catches invalid regex pattern."""
-        # The ValidationRule model should catch this during creation
-        from pydantic import ValidationError
+        """Test that validator catches invalid regex pattern."""
+        rule = ValidationRule(
+            rule_type="core:regex_match",
+            description="Invalid regex",
+            params={"file_path": "test.md", "pattern": r"[invalid(regex"},  # Unclosed bracket
+            failure_message="Invalid pattern",
+            expected_behavior="Should have valid pattern",
+        )
 
-        with pytest.raises(ValidationError, match="Invalid regex pattern"):
-            ValidationRule(
-                rule_type="core:regex_match",
-                description="Invalid regex",
-                file_path="test.md",
-                pattern=r"[invalid(regex",  # Unclosed bracket
-                failure_message="Invalid pattern",
-                expected_behavior="Should have valid pattern",
-            )
+        with pytest.raises(ValueError, match="Invalid regex pattern"):
+            validator.validate(rule, bundle_with_file)
 
     def test_regex_match_read_error(self, validator, tmp_path):
         """Test validation when file cannot be read."""
@@ -248,8 +241,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Read protected file",
-            file_path="test.md",
-            pattern=r"test",
+            params={"file_path": "test.md", "pattern": r"test"},
             failure_message="Cannot read",
             expected_behavior="Should be readable",
         )
@@ -290,8 +282,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Case-sensitive match",
-            file_path="test.md",
-            pattern=r"hello",
+            params={"file_path": "test.md", "pattern": r"hello"},
             failure_message="Pattern not found",
             expected_behavior="Should match",
         )
@@ -322,9 +313,7 @@ class TestRegexMatchValidator:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Case-insensitive match",
-            file_path="test.md",
-            pattern=r"hello",
-            flags=re.IGNORECASE,
+            params={"file_path": "test.md", "pattern": r"hello", "flags": re.IGNORECASE},
             failure_message="Pattern not found",
             expected_behavior="Should match",
         )

--- a/tests/unit/test_token_count_validator.py
+++ b/tests/unit/test_token_count_validator.py
@@ -69,9 +69,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check CLAUDE.md token count",
-            file_path="CLAUDE.md",
-            max_count=1500,
-            params={"provider": "anthropic"},
+            params={"file_path": "CLAUDE.md", "max_count": 1500, "provider": "anthropic"},
             failure_message="CLAUDE.md exceeds 1500 tokens",
             expected_behavior="CLAUDE.md should be under 1500 tokens",
         )
@@ -120,9 +118,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check CLAUDE.md token count",
-            file_path="CLAUDE.md",
-            max_count=1500,
-            params={"provider": "anthropic"},
+            params={"file_path": "CLAUDE.md", "max_count": 1500, "provider": "anthropic"},
             failure_message="CLAUDE.md exceeds 1500 tokens",
             expected_behavior="CLAUDE.md should be under 1500 tokens",
         )
@@ -174,9 +170,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=1000,
-            params={"provider": "anthropic"},
+            params={"file_path": "test.md", "max_count": 1000, "provider": "anthropic"},
             failure_message="Too many tokens",
             expected_behavior="Should be under limit",
         )
@@ -224,9 +218,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=100,
-            params={"provider": "openai"},
+            params={"file_path": "test.md", "max_count": 100, "provider": "openai"},
             failure_message="Too many tokens",
             expected_behavior="Should be under 100 tokens",
         )
@@ -265,9 +257,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=100,
-            params={"provider": "openai"},
+            params={"file_path": "test.md", "max_count": 100, "provider": "openai"},
             failure_message="Too many tokens",
             expected_behavior="Should be under 100 tokens",
         )
@@ -309,9 +299,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=1000,
-            params={"provider": "openai"},
+            params={"file_path": "test.md", "max_count": 1000, "provider": "openai"},
             failure_message="Too many tokens",
             expected_behavior="Should be under limit",
         )
@@ -359,9 +347,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=100,
-            params={"provider": "llama"},
+            params={"file_path": "test.md", "max_count": 100, "provider": "llama"},
             failure_message="Too many tokens",
             expected_behavior="Should be under 100 tokens",
         )
@@ -400,9 +386,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=1000,
-            params={"provider": "llama"},
+            params={"file_path": "test.md", "max_count": 1000, "provider": "llama"},
             failure_message="Too many tokens",
             expected_behavior="Should be under limit",
         )
@@ -422,9 +406,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=1000,
-            params={"provider": "unsupported"},
+            params={"file_path": "test.md", "max_count": 1000, "provider": "unsupported"},
             failure_message="Too many tokens",
             expected_behavior="Should be under limit",
         )
@@ -456,17 +438,18 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check token count",
-            file_path="test.md",
-            max_count=1000,
+            params={"file_path": "test.md", "max_count": 1000},
             failure_message="Too many tokens",
             expected_behavior="Should be under limit",
         )
 
         # Mock ImportError for anthropic package
+        original_import = __import__
+
         def mock_import(name, *args, **kwargs):
             if name == "anthropic":
                 raise ImportError("No module named 'anthropic'")
-            return __import__(name, *args, **kwargs)
+            return original_import(name, *args, **kwargs)
 
         monkeypatch.setattr("builtins.__import__", mock_import)
 
@@ -479,9 +462,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check nonexistent file",
-            file_path="nonexistent.md",
-            max_count=1000,
-            params={"provider": "anthropic"},
+            params={"file_path": "nonexistent.md", "max_count": 1000, "provider": "anthropic"},
             failure_message="File not found",
             expected_behavior="File should exist",
         )
@@ -502,7 +483,7 @@ class TestTokenCountValidator:
             expected_behavior="Should error",
         )
 
-        with pytest.raises(ValueError, match="requires rule.file_path"):
+        with pytest.raises(ValueError, match="requires params.file_path"):
             validator.validate(rule, bundle_with_file)
 
     def test_file_read_error(self, validator, tmp_path):
@@ -528,9 +509,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Read protected file",
-            file_path="test.md",
-            max_count=1000,
-            params={"provider": "anthropic"},
+            params={"file_path": "test.md", "max_count": 1000, "provider": "anthropic"},
             failure_message="Cannot read",
             expected_behavior="Should be readable",
         )
@@ -566,9 +545,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check minimum tokens",
-            file_path="test.md",
-            min_count=100,
-            params={"provider": "anthropic"},
+            params={"file_path": "test.md", "min_count": 100, "provider": "anthropic"},
             failure_message="Too few tokens",
             expected_behavior="Should have at least 100 tokens",
         )
@@ -605,8 +582,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="No constraints",
-            file_path="test.md",
-            params={"provider": "anthropic"},
+            params={"file_path": "test.md", "provider": "anthropic"},
             failure_message="Error",
             expected_behavior="Should pass",
         )
@@ -645,9 +621,7 @@ class TestTokenCountValidator:
         rule = ValidationRule(
             rule_type="core:token_count",
             description="Check tokens",
-            file_path="test.md",
-            max_count=1000,
-            params={"provider": "anthropic"},
+            params={"file_path": "test.md", "max_count": 1000, "provider": "anthropic"},
             failure_message="Error",
             expected_behavior="Should work",
         )

--- a/tests/unit/test_validator_default_messages.py
+++ b/tests/unit/test_validator_default_messages.py
@@ -158,7 +158,7 @@ class TestFileExistsValidatorDefaultMessages:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check file",
-            file_path="missing.txt",
+            params={"file_path": "missing.txt"},
             failure_message=None,  # No custom message
             expected_behavior=None,  # No custom behavior
         )
@@ -178,7 +178,7 @@ class TestFileExistsValidatorDefaultMessages:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check file",
-            file_path="missing.txt",
+            params={"file_path": "missing.txt"},
             failure_message="Custom: File {file_path} is missing!",
             expected_behavior="Custom: File should exist",
         )
@@ -233,7 +233,7 @@ class TestValidationRuleOptionalMessages:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Test rule",
-            file_path="test.txt",
+            params={"file_path": "test.txt"},
             failure_message="Custom failure",
         )
 
@@ -245,7 +245,7 @@ class TestValidationRuleOptionalMessages:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Test rule",
-            file_path="test.txt",
+            params={"file_path": "test.txt"},
             expected_behavior="Custom expected",
         )
 
@@ -257,7 +257,7 @@ class TestValidationRuleOptionalMessages:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Test rule",
-            file_path="test.txt",
+            params={"file_path": "test.txt"},
             failure_message="Custom failure",
             expected_behavior="Custom expected",
         )

--- a/tests/unit/test_validator_param_handling.py
+++ b/tests/unit/test_validator_param_handling.py
@@ -1,0 +1,918 @@
+"""Tests for validator parameter handling.
+
+This test suite ensures validators consistently use rule.params dict,
+catching regressions if implementation changes.
+
+REQUIRED PATTERN:
+- Core rule fields: type, description, failure_message, expected_behavior
+- Validator-specific parameters: EVERYTHING ELSE under params:
+
+Example:
+    rule = ValidationRule(
+        rule_type="core:regex_match",
+        description="Check pattern",
+        params={
+            "pattern": r"## Prerequisites",
+            "flags": re.MULTILINE,
+            "file_path": "README.md"
+        }
+    )
+"""
+
+import re
+
+import pytest
+
+from drift.config.models import ValidationRule
+from drift.core.types import DocumentBundle, DocumentFile
+from drift.validation.validators.core.block_validators import BlockLineCountValidator
+from drift.validation.validators.core.file_validators import FileExistsValidator, FileSizeValidator
+from drift.validation.validators.core.format_validators import (
+    JsonSchemaValidator,
+    YamlFrontmatterValidator,
+    YamlSchemaValidator,
+)
+from drift.validation.validators.core.markdown_validators import MarkdownLinkValidator
+from drift.validation.validators.core.regex_validators import RegexMatchValidator
+
+
+class TestRegexMatchValidatorParams:
+    """Tests for RegexMatchValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return RegexMatchValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    @pytest.fixture
+    def bundle_with_file(self, tmp_path):
+        """Create bundle with a test file."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("# Header\n## Prerequisites\nContent")
+
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content="# Header\n## Prerequisites\nContent",
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+    def test_missing_pattern_raises_error(self, validator, bundle_with_file):
+        """Test that validator raises clear error when pattern is missing."""
+        rule = ValidationRule(
+            rule_type="core:regex_match",
+            description="Check pattern",
+            params={"file_path": "test.md"},  # Has params, but missing pattern
+        )
+
+        with pytest.raises(ValueError, match="requires.*pattern"):
+            validator.validate(rule, bundle_with_file)
+
+    def test_pattern_from_params(self, validator, bundle_with_file):
+        """Test that validator reads pattern from params."""
+        rule = ValidationRule(
+            rule_type="core:regex_match",
+            description="Check for Prerequisites",
+            params={
+                "pattern": r"## Prerequisites",
+                "file_path": "test.md",
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_file)
+        assert result is None
+
+    def test_flags_from_params(self, validator, tmp_path):
+        """Test that validator reads flags from params."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("First line\nSecond line")
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.txt",
+                    content="First line\nSecond line",
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:regex_match",
+            description="Match line start",
+            params={
+                "pattern": r"^Second",
+                "flags": re.MULTILINE,
+                "file_path": "test.txt",
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_invalid_regex_pattern_caught_by_model(self, validator, bundle_with_file):
+        """Test that ValidationRule model catches invalid regex patterns."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="Invalid regex pattern"):
+            ValidationRule(
+                rule_type="core:regex_match",
+                description="Invalid regex",
+                pattern=r"[invalid(regex",
+            )
+
+
+class TestFileExistsValidatorParams:
+    """Tests for FileExistsValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return FileExistsValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    @pytest.fixture
+    def bundle(self, tmp_path):
+        """Create basic bundle."""
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+    def test_missing_file_path_param_raises_error(self, validator, bundle):
+        """Test that validator raises clear error when file_path is missing."""
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check file exists",
+            params={},  # Empty params, no file_path
+        )
+
+        with pytest.raises(ValueError, match="requires params"):
+            validator.validate(rule, bundle)
+
+    def test_file_path_from_params(self, validator, tmp_path):
+        """Test that validator reads from params.file_path."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("content")
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check file exists",
+            params={"file_path": "test.md"},
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_glob_pattern_in_file_path(self, validator, tmp_path):
+        """Test file_path with glob patterns."""
+        skills_dir = tmp_path / ".claude" / "skills" / "testing"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("# Testing Skill")
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:file_exists",
+            description="Check skill files exist",
+            params={"file_path": ".claude/skills/*/SKILL.md"},
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+
+class TestFileSizeValidatorParams:
+    """Tests for FileSizeValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return FileSizeValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    @pytest.fixture
+    def bundle(self, tmp_path):
+        """Create basic bundle."""
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+    def test_missing_file_path_param_raises_error(self, validator, bundle):
+        """Test that validator raises clear error when file_path is missing."""
+        rule = ValidationRule(
+            rule_type="core:file_size",
+            description="Check file size",
+            params={},  # Empty params, no file_path
+        )
+
+        with pytest.raises(ValueError, match="requires params"):
+            validator.validate(rule, bundle)
+
+    def test_max_count_from_params(self, validator, tmp_path):
+        """Test that validator reads max_count from params."""
+        test_file = tmp_path / "test.md"
+        content = "\n".join([f"Line {i}" for i in range(50)])
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:file_size",
+            description="Check line count",
+            params={"file_path": "test.md", "max_count": 100},
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_min_count_from_params(self, validator, tmp_path):
+        """Test that validator reads min_count from params."""
+        test_file = tmp_path / "test.md"
+        content = "\n".join([f"Line {i}" for i in range(5)])
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:file_size",
+            description="Check minimum lines",
+            params={"file_path": "test.md", "min_count": 10},
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "below min 10" in result.observed_issue
+
+    def test_max_size_from_params(self, validator, tmp_path):
+        """Test that validator reads max_size from params."""
+        test_file = tmp_path / "test.txt"
+        content = "a" * 500
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="skill",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.txt",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:file_size",
+            description="Check byte size",
+            params={"file_path": "test.txt", "max_size": 1000},
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+
+class TestBlockLineCountValidatorParams:
+    """Tests for BlockLineCountValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return BlockLineCountValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    @pytest.fixture
+    def bundle_with_blocks(self, tmp_path):
+        """Create bundle with code blocks."""
+        content = """```python
+print("hello")
+```
+
+```
+x = 1
+y = 2
+```"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+    def test_missing_pattern_start_raises_error(self, validator, tmp_path):
+        """Test that validator raises error when params.pattern_start is missing."""
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                # Missing pattern_start!
+                "pattern_end": "^```",
+                "min_lines": 1,
+            },
+        )
+
+        with pytest.raises(ValueError, match="requires params.pattern_start"):
+            validator.validate(rule, bundle)
+
+    def test_missing_pattern_end_raises_error(self, validator, tmp_path):
+        """Test that validator raises error when params.pattern_end is missing."""
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                # Missing pattern_end!
+                "min_lines": 1,
+            },
+        )
+
+        with pytest.raises(ValueError, match="requires params.pattern_end"):
+            validator.validate(rule, bundle)
+
+    def test_missing_threshold_raises_error(self, validator, tmp_path):
+        """Test that validator raises error when no threshold specified."""
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+            },
+        )
+
+        with pytest.raises(
+            ValueError, match="requires at least one of: params.min_lines, params.max_lines"
+        ):
+            validator.validate(rule, bundle)
+
+    def test_pattern_start_from_params(self, validator, bundle_with_blocks):
+        """Test that validator reads pattern_start from params."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_blocks)
+        assert result is None
+
+    def test_min_lines_from_params(self, validator, bundle_with_blocks):
+        """Test that validator reads min_lines from params."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 5,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_blocks)
+        assert result is not None
+        assert "violation" in result.observed_issue.lower()
+
+    def test_max_lines_from_params(self, validator, bundle_with_blocks):
+        """Test that validator reads max_lines from params."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "max_lines": 10,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_blocks)
+        assert result is None
+
+    def test_exact_lines_from_params(self, validator, tmp_path):
+        """Test that validator reads exact_lines from params."""
+        content = """```
+line1
+line2
+```"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "exact_lines": 2,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_files_from_params(self, validator, bundle_with_blocks):
+        """Test that validator reads files from params."""
+        rule = ValidationRule(
+            rule_type="core:block_line_count",
+            description="Check blocks",
+            params={
+                "pattern_start": "^```",
+                "pattern_end": "^```",
+                "min_lines": 1,
+                "files": ["test.md"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_blocks)
+        assert result is None
+
+
+class TestMarkdownLinkValidatorParams:
+    """Tests for MarkdownLinkValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return MarkdownLinkValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    @pytest.fixture
+    def bundle_with_links(self, tmp_path):
+        """Create bundle with markdown file containing links."""
+        content = """# Test
+[Local](./local.md)
+[External](https://example.com)
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+    def test_check_local_files_from_params(self, validator, bundle_with_links):
+        """Test that validator reads check_local_files from params."""
+        rule = ValidationRule(
+            rule_type="core:markdown_link",
+            description="Check links",
+            params={
+                "check_local_files": True,
+                "check_external_urls": False,
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_links)
+        assert result is not None
+        assert "local.md" in result.observed_issue
+
+    def test_check_external_urls_from_params(self, validator, tmp_path):
+        """Test that validator reads check_external_urls from params."""
+        local_file = tmp_path / "local.md"
+        local_file.write_text("content")
+
+        content = """# Test
+[Local](./local.md)
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:markdown_link",
+            description="Check links",
+            params={
+                "check_local_files": True,
+                "check_external_urls": False,
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+    def test_skip_example_domains_from_params(self, validator, tmp_path):
+        """Test that validator reads skip_example_domains from params."""
+        content = """# Test
+[Example](https://example.com)
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:markdown_link",
+            description="Check links",
+            params={
+                "check_local_files": False,
+                "check_external_urls": True,
+                "skip_example_domains": True,
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+
+class TestYamlFrontmatterValidatorParams:
+    """Tests for YamlFrontmatterValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return YamlFrontmatterValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    @pytest.fixture
+    def bundle_with_frontmatter(self, tmp_path):
+        """Create bundle with file containing YAML frontmatter."""
+        content = """---
+title: Test
+author: John
+---
+
+# Content
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        return DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+    def test_required_fields_from_params(self, validator, bundle_with_frontmatter):
+        """Test that validator reads required_fields from params."""
+        rule = ValidationRule(
+            rule_type="core:yaml_frontmatter",
+            description="Check frontmatter",
+            params={
+                "required_fields": ["title", "author"],
+            },
+        )
+
+        result = validator.validate(rule, bundle_with_frontmatter)
+        assert result is None
+
+    def test_schema_from_params(self, validator, tmp_path):
+        """Test that validator reads schema from params."""
+        content = """---
+title: Test
+count: 42
+---
+
+# Content
+"""
+        test_file = tmp_path / "test.md"
+        test_file.write_text(content)
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="documentation",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[
+                DocumentFile(
+                    relative_path="test.md",
+                    content=content,
+                    file_path=str(test_file),
+                )
+            ],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:yaml_frontmatter",
+            description="Check frontmatter schema",
+            params={
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "count": {"type": "number"},
+                    },
+                    "required": ["title", "count"],
+                }
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+
+class TestJsonSchemaValidatorParams:
+    """Tests for JsonSchemaValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return JsonSchemaValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    def test_missing_schema_returns_error(self, validator, tmp_path):
+        """Test that validator returns error when schema is missing from params."""
+        test_file = tmp_path / "test.json"
+        test_file.write_text('{"key": "value"}')
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="config",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:json_schema",
+            description="Validate JSON",
+            params={"file_path": "test.json"},  # Has file_path but no schema
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "schema" in result.observed_issue.lower()
+
+    def test_schema_from_params(self, validator, tmp_path):
+        """Test that validator reads schema from params."""
+        test_file = tmp_path / "test.json"
+        test_file.write_text('{"name": "test", "count": 42}')
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="config",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:json_schema",
+            description="Validate JSON",
+            params={
+                "file_path": "test.json",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "count": {"type": "number"},
+                    },
+                    "required": ["name", "count"],
+                },
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None
+
+
+class TestYamlSchemaValidatorParams:
+    """Tests for YamlSchemaValidator parameter handling."""
+
+    @pytest.fixture
+    def validator(self):
+        """Create validator instance."""
+        return YamlSchemaValidator()
+
+    @pytest.fixture
+    def tmp_path(self, tmp_path):
+        """Provide tmp_path fixture."""
+        return tmp_path
+
+    def test_missing_schema_returns_error(self, validator, tmp_path):
+        """Test that validator returns error when schema is missing from params."""
+        test_file = tmp_path / "test.yaml"
+        test_file.write_text("key: value\n")
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="config",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:yaml_schema",
+            description="Validate YAML",
+            params={"file_path": "test.yaml"},  # Has file_path but no schema
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "schema" in result.observed_issue.lower()
+
+    def test_schema_from_params(self, validator, tmp_path):
+        """Test that validator reads schema from params."""
+        test_file = tmp_path / "test.yaml"
+        test_file.write_text("name: test\ncount: 42\n")
+
+        bundle = DocumentBundle(
+            bundle_id="test",
+            bundle_type="config",
+            bundle_strategy="individual",
+            project_path=tmp_path,
+            files=[],
+        )
+
+        rule = ValidationRule(
+            rule_type="core:yaml_schema",
+            description="Validate YAML",
+            params={
+                "file_path": "test.yaml",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "count": {"type": "number"},
+                    },
+                    "required": ["name", "count"],
+                },
+            },
+        )
+
+        result = validator.validate(rule, bundle)
+        assert result is None

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -23,12 +23,12 @@ class TestValidationRule:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check CLAUDE.md exists",
-            file_path="CLAUDE.md",
+            params={"file_path": "CLAUDE.md"},
             failure_message="CLAUDE.md not found",
             expected_behavior="CLAUDE.md should exist",
         )
         assert rule.rule_type == "core:file_exists"
-        assert rule.file_path == "CLAUDE.md"
+        assert rule.params["file_path"] == "CLAUDE.md"
         assert rule.pattern is None
 
     def test_valid_regex_rule(self):
@@ -36,13 +36,13 @@ class TestValidationRule:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check for Prerequisites section",
-            pattern=r"^## Prerequisites",
+            params={"pattern": r"^## Prerequisites"},
             flags=re.MULTILINE,
             failure_message="Missing Prerequisites section",
             expected_behavior="Should have Prerequisites section",
         )
         assert rule.rule_type == "core:regex_match"
-        assert rule.pattern == r"^## Prerequisites"
+        assert rule.params["pattern"] == r"^## Prerequisites"
         assert rule.flags == re.MULTILINE
 
     def test_valid_file_size_rule(self):
@@ -50,7 +50,7 @@ class TestValidationRule:
         rule = ValidationRule(
             rule_type="core:file_size",
             description="Limit number of lines in commands",
-            file_path=".claude/commands/test.md",
+            params={"file_path": ".claude/commands/test.md"},
             max_count=20,
             failure_message="Too many lines",
             expected_behavior="Should have <= 20 lines",
@@ -75,12 +75,12 @@ class TestValidationRule:
         assert rule.reference_pattern is not None
 
     def test_invalid_regex_pattern(self):
-        """Test that invalid regex pattern raises ValidationError."""
+        """Test that invalid regex pattern raises ValidationError on legacy pattern field."""
         with pytest.raises(ValidationError) as exc_info:
             ValidationRule(
                 rule_type="core:regex_match",
                 description="Invalid regex",
-                pattern=r"[invalid(regex",  # Unclosed bracket
+                pattern=r"[invalid(regex",  # Using legacy field which is validated
                 failure_message="Test",
                 expected_behavior="Test",
             )
@@ -107,7 +107,7 @@ class TestValidationRulesConfig:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Test rule",
-            file_path="test.md",
+            params={"file_path": "test.md"},
             failure_message="Test failure",
             expected_behavior="Test expected",
         )
@@ -133,7 +133,7 @@ class TestValidationRulesConfig:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Test",
-            file_path="test.md",
+            params={"file_path": "test.md"},
             failure_message="Test",
             expected_behavior="Test",
         )
@@ -157,14 +157,14 @@ class TestValidationRulesConfig:
             ValidationRule(
                 rule_type="core:file_exists",
                 description="Rule 1",
-                file_path="test1.md",
+                params={"file_path": "test1.md"},
                 failure_message="Test 1",
                 expected_behavior="Test 1",
             ),
             ValidationRule(
                 rule_type="core:file_exists",
                 description="Rule 2",
-                file_path="test2.md",
+                params={"file_path": "test2.md"},
                 failure_message="Test 2",
                 expected_behavior="Test 2",
             ),
@@ -217,7 +217,7 @@ class TestFileExistsValidator:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check README exists",
-            file_path="README.md",
+            params={"file_path": "README.md"},
             failure_message="README not found",
             expected_behavior="README should exist",
         )
@@ -232,7 +232,7 @@ class TestFileExistsValidator:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check missing file",
-            file_path="MISSING.md",
+            params={"file_path": "MISSING.md"},
             failure_message="MISSING.md not found",
             expected_behavior="MISSING.md should exist",
         )
@@ -250,7 +250,7 @@ class TestFileExistsValidator:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check skill files exist",
-            file_path=".claude/skills/*/SKILL.md",
+            params={"file_path": ".claude/skills/*/SKILL.md"},
             failure_message="No skill files found",
             expected_behavior="Skill files should exist",
         )
@@ -270,7 +270,7 @@ class TestFileExistsValidator:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check missing pattern",
-            file_path=".claude/commands/*.md",
+            params={"file_path": ".claude/commands/*.md"},
             failure_message="No command files found",
             expected_behavior="Command files should exist",
         )
@@ -294,7 +294,7 @@ class TestFileExistsValidator:
         with pytest.raises(ValueError) as exc_info:
             validator.validate(rule, sample_bundle)
 
-        assert "requires rule.file_path" in str(exc_info.value)
+        assert "requires params" in str(exc_info.value)
 
 
 class TestValidatorRegistry:
@@ -329,7 +329,7 @@ class TestValidatorRegistry:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check file exists",
-            file_path="EXISTS.md",
+            params={"file_path": "EXISTS.md"},
             failure_message="File not found",
             expected_behavior="File should exist",
         )
@@ -344,7 +344,7 @@ class TestValidatorRegistry:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check missing file",
-            file_path="MISSING.md",
+            params={"file_path": "MISSING.md"},
             failure_message="File not found",
             expected_behavior="File should exist",
         )
@@ -363,8 +363,7 @@ class TestValidatorRegistry:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check for pattern",
-            file_path="test.txt",
-            pattern=r"Test Pattern",
+            params={"pattern": r"Test Pattern"},
             failure_message="Pattern not found",
             expected_behavior="Pattern should exist",
         )

--- a/tests/unit/test_validators_default_messages_real.py
+++ b/tests/unit/test_validators_default_messages_real.py
@@ -41,7 +41,7 @@ class TestFileExistsValidatorDefaults:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check file exists",
-            file_path="missing.txt",
+            params={"file_path": "missing.txt"},
             # No failure_message or expected_behavior - should use defaults
         )
 
@@ -65,7 +65,7 @@ class TestFileExistsValidatorDefaults:
         rule = ValidationRule(
             rule_type="core:file_exists",
             description="Check file exists",
-            file_path="missing.txt",
+            params={"file_path": "missing.txt"},
             failure_message="CUSTOM: File {file_path} is missing!",
             expected_behavior="CUSTOM: File must be present",
         )
@@ -125,7 +125,7 @@ class TestRegexMatchValidatorDefaults:
         rule = ValidationRule(
             rule_type="core:regex_match",
             description="Check pattern",
-            pattern=r"MISSING_PATTERN",
+            params={"pattern": r"MISSING_PATTERN"},
             # No custom messages
         )
 
@@ -229,13 +229,13 @@ class TestJsonSchemaValidatorDefaults:
         rule = ValidationRule(
             rule_type="core:json_schema",
             description="Validate JSON schema",
-            file_path="test.json",  # JsonSchemaValidator requires this
             params={
+                "file_path": "test.json",
                 "schema": {
                     "type": "object",
                     "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
                     "required": ["name", "age"],  # Missing 'age'
-                }
+                },
             },
             # No custom messages
         )
@@ -275,13 +275,13 @@ class TestYamlSchemaValidatorDefaults:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate YAML schema",
-            file_path="test.yaml",  # YamlSchemaValidator requires this
             params={
+                "file_path": "test.yaml",
                 "schema": {
                     "type": "object",
                     "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
                     "required": ["name", "age"],  # Missing 'age'
-                }
+                },
             },
             # No custom messages
         )

--- a/tests/unit/test_yaml_schema_validator.py
+++ b/tests/unit/test_yaml_schema_validator.py
@@ -55,8 +55,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate config.yaml",
-            file_path="config.yaml",
-            params={"schema": schema},
+            params={"file_path": "config.yaml", "schema": schema},
             failure_message="Invalid YAML structure",
             expected_behavior="Should match schema",
         )
@@ -82,8 +81,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate config.yaml",
-            file_path="config.yaml",
-            params={"schema": schema},
+            params={"file_path": "config.yaml", "schema": schema},
             failure_message="Invalid YAML structure",
             expected_behavior="Should match schema",
         )
@@ -109,8 +107,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate config.yaml",
-            file_path="config.yaml",
-            params={"schema": schema},
+            params={"file_path": "config.yaml", "schema": schema},
             failure_message="Invalid YAML structure",
             expected_behavior="Should match schema",
         )
@@ -141,8 +138,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate data.yaml",
-            file_path="data.yaml",
-            params={"schema_file": "schema.json"},
+            params={"file_path": "data.yaml", "schema_file": "schema.json"},
             failure_message="YAML doesn't match schema",
             expected_behavior="Should conform to schema",
         )
@@ -158,8 +154,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate data.yaml",
-            file_path="data.yaml",
-            params={"schema_file": "nonexistent.json"},
+            params={"file_path": "data.yaml", "schema_file": "nonexistent.json"},
             failure_message="YAML doesn't match schema",
             expected_behavior="Should conform to schema",
         )
@@ -178,24 +173,25 @@ class TestYamlSchemaValidator:
             expected_behavior="Expected",
         )
 
-        with pytest.raises(ValueError, match="requires rule.file_path"):
+        with pytest.raises(ValueError, match="requires params.file_path"):
             validator.validate(rule, bundle)
 
     def test_missing_params(self, validator, bundle, tmp_path):
-        """Test that validation fails when params is missing."""
+        """Test that validation fails when schema/schema_file is missing."""
         test_file = tmp_path / "data.yaml"
         test_file.write_text("key: value\n")
 
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
+            params={"file_path": "data.yaml"},
             failure_message="Failure",
             expected_behavior="Expected",
         )
 
-        with pytest.raises(ValueError, match="requires params"):
-            validator.validate(rule, bundle)
+        result = validator.validate(rule, bundle)
+        assert result is not None
+        assert "requires 'schema' or 'schema_file'" in result.observed_issue
 
     def test_missing_schema_and_schema_file_in_params(self, validator, bundle, tmp_path):
         """Test error when params has neither schema nor schema_file."""
@@ -205,8 +201,10 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"other_key": "value"},  # Has params but no schema/schema_file
+            params={
+                "file_path": "data.yaml",
+                "other_key": "value",
+            },  # Has params but no schema/schema_file
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -220,8 +218,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="nonexistent.yaml",
-            params={"schema": {"type": "object"}},
+            params={"file_path": "nonexistent.yaml", "schema": {"type": "object"}},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -238,8 +235,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="invalid.yaml",
-            params={"schema": {"type": "object"}},
+            params={"file_path": "invalid.yaml", "schema": {"type": "object"}},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -261,8 +257,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema": {"type": "object"}},
+            params={"file_path": "data.yaml", "schema": {"type": "object"}},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -309,8 +304,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate nested config",
-            file_path="config.yaml",
-            params={"schema": schema},
+            params={"file_path": "config.yaml", "schema": schema},
             failure_message="Invalid structure",
             expected_behavior="Should match nested schema",
         )
@@ -345,8 +339,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Validate array",
-            file_path="list.yaml",
-            params={"schema": schema},
+            params={"file_path": "list.yaml", "schema": schema},
             failure_message="Invalid array",
             expected_behavior="Should match array schema",
         )
@@ -388,8 +381,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema": schema},
+            params={"file_path": "data.yaml", "schema": schema},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -428,8 +420,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema": schema},
+            params={"file_path": "data.yaml", "schema": schema},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -469,8 +460,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema_file": "schema.json"},
+            params={"file_path": "data.yaml", "schema_file": "schema.json"},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -506,8 +496,7 @@ class TestYamlSchemaValidator:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema_file": "schema.json"},
+            params={"file_path": "data.yaml", "schema_file": "schema.json"},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -547,8 +536,7 @@ required:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema_file": "schema.yaml"},
+            params={"file_path": "data.yaml", "schema_file": "schema.yaml"},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -582,8 +570,7 @@ required:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema": schema},
+            params={"file_path": "data.yaml", "schema": schema},
             failure_message="Failure",
             expected_behavior="Expected",
         )
@@ -613,8 +600,7 @@ required:
         rule = ValidationRule(
             rule_type="core:yaml_schema",
             description="Test rule",
-            file_path="data.yaml",
-            params={"schema": schema},
+            params={"file_path": "data.yaml", "schema": schema},
             failure_message="Failure",
             expected_behavior="Expected",
         )


### PR DESCRIPTION
## Summary

- Added `block_line_count` validator for checking line counts within paired delimiters (code blocks, YAML sections, etc.)
- Supports min/max/exact line count thresholds
- Handles unpaired delimiters and empty blocks with clear error messages

## Changes

### Added
- `src/drift/validation/validators/core/block_validators.py` - BlockLineCountValidator implementation
- `tests/unit/test_block_line_count_validator.py` - Test suite
- `docs/validators.md` - Documentation with examples
- `.claude/skills/test-strategy/` - Test strategy skill resources

### Modified
- `src/drift/config/models.py` - Validator registration
- `.drift_rules.yaml` - Updated to use params dict structure consistently
- Updated existing validators to use consistent params dict pattern

## Related Issues

Closes #49