### PR TITLE
Issue #56: Add rule documentation generation command

### DIFF
--- a/.claude/skills/pr-writing/SKILL.md
+++ b/.claude/skills/pr-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-writing
-description: Expert in creating well-structured pull requests with clear summaries and test plans. Use when writing or structuring PRs.
+description: Expert in creating well-structured pull requests with clear summaries. Use when writing or structuring PRs.
 ---
 
 # PR Writing Skill
@@ -13,9 +13,8 @@ Learn how to create well-structured, reviewable pull requests using the GitHub M
 
 A well-structured PR includes:
 1. **Summary** - What changed and why
-2. **Test Plan** - How you verified it works
-3. **Changes** - What files were affected
-4. **Related Issues** - Links to relevant issues
+2. **Changes** - What files were affected
+3. **Related Issues** - Links to relevant issues
 
 **Example structure:**
 ```markdown
@@ -23,12 +22,6 @@ A well-structured PR includes:
 - Added multi-drift-type analysis support
 - Implemented sequential processing for each type
 - Combined results in unified output format
-
-## Test Plan
-- [x] Unit tests added (10 new tests)
-- [x] Coverage at 92%
-- [x] Manual testing with multiple drift types
-- [x] All linters passing
 
 ## Changes
 ### Added
@@ -67,27 +60,6 @@ Focus on WHAT changed and WHY, not HOW:
 - Changed line 45 in cli.py to add a new variable called cache_dict
 - Updated the error handling function to print better messages
 - Added a lock object to the ProcessPool initialization
-```
-
-### How to Write Test Plans
-
-Checklist format works best:
-
-**Good example:**
-```markdown
-## Test Plan
-- [x] Unit tests added (12 new tests)
-- [x] Coverage increased from 88% to 93%
-- [x] Manual testing with 5 different config formats
-- [x] Tested with both Bedrock and Anthropic API
-- [x] All linters passing (./lint.sh)
-```
-
-**Avoid vague statements:**
-```markdown
-## Test Plan
-- Tests added
-- Everything works
 ```
 
 ### How to Document Changes
@@ -137,13 +109,6 @@ mcp__github__create_pull_request(
 - Added multi-drift-type analysis support to CLI
 - Implemented sequential processing for each drift type
 - Combined results in unified output format
-
-## Test Plan
-
-- [x] Unit tests added (10 new tests)
-- [x] Coverage at 92%
-- [x] Manual testing with multiple types
-- [x] All linters passing
 
 ## Changes
 
@@ -387,12 +352,6 @@ pr = mcp__github__create_pull_request(
 - Added CustomValidator base class
 - Implemented plugin loading system
 - Updated config schema
-
-## Test Plan
-- [x] Unit tests (12 new)
-- [x] Integration tests (3 new)
-- [x] Coverage at 95%
-- [x] Manual testing with example validators
 
 ## Changes
 

--- a/.claude/skills/pr-writing/resources/good-examples.md
+++ b/.claude/skills/pr-writing/resources/good-examples.md
@@ -17,19 +17,6 @@ Examples of excellent pull requests with annotations.
 - Each drift type gets separate API call for clearer prompts and better results
 - Output format groups detections by type for easy scanning
 
-## Test Plan
-
-- [ ] Unit tests for multi-type argument parsing (tests/unit/test_cli.py)
-- [ ] Integration tests for multi-pass analysis (tests/integration/test_multi_pass.py)
-- [ ] Coverage at 92% (above 90% threshold)
-- [ ] Manual testing:
-  - [ ] Single drift type (backward compatibility)
-  - [ ] Two drift types (incomplete_work + incorrect_tool)
-  - [ ] All built-in drift types (5 types)
-  - [ ] Custom + built-in types mixed
-  - [ ] Empty results handling
-- [ ] All linters passing (flake8, black, isort, mypy)
-
 ## Changes
 
 ### Added
@@ -59,7 +46,6 @@ Relates to #15 - Configuration improvements (enables per-type config)
 
 **Why this is excellent:**
 - ✅ Clear summary with key decisions explained
-- ✅ Comprehensive test plan with specific scenarios
 - ✅ File changes with line numbers
 - ✅ Shows backward compatibility consideration
 - ✅ Links related issues
@@ -75,14 +61,6 @@ Relates to #15 - Configuration improvements (enables per-type config)
 - Fixed config parser crash when .drift.yaml is missing `drift_types` section
 - Root cause: Code assumed all config sections were present
 - Solution: Added safe dict access with built-in defaults
-
-## Test Plan
-
-- [ ] Test prevents regression (tests/unit/test_config.py::test_missing_drift_types)
-- [ ] Verified fix with minimal .drift.yaml (only llm_config section)
-- [ ] All existing tests still pass (no behavior change for valid configs)
-- [ ] Coverage maintained at 91%
-- [ ] Linters passing
 
 ## Changes
 
@@ -104,8 +82,7 @@ Fixes #56 - Config parser crashes on missing drift_types section
 
 **Why this is excellent:**
 - ✅ Explains root cause and solution
-- ✅ Shows regression test added
-- ✅ Confirms no side effects
+- ✅ Adds regression test
 - ✅ Concise but complete
 
 ---
@@ -124,17 +101,6 @@ Fixes #56 - Config parser crashes on missing drift_types section
 - Easier to test (providers can be mocked independently)
 - Simpler to add new providers (implement base interface)
 - Clearer separation of concerns (detection vs LLM interaction)
-
-## Test Plan
-
-- [ ] All existing tests pass (158/158 passing)
-- [ ] New tests for provider abstraction (tests/unit/test_providers.py)
-- [ ] Coverage increased to 93% (was 91%)
-- [ ] Manual verification:
-  - [ ] Bedrock provider works as before
-  - [ ] All drift types still functional
-  - [ ] Error handling unchanged
-- [ ] Linters passing
 
 ## Changes
 
@@ -163,7 +129,7 @@ Improves #23 - Better testability
 
 **Why this is excellent:**
 - ✅ Explains refactoring motivation
-- ✅ Shows no behavior change (all tests pass)
+- ✅ Confirms no behavior change
 - ✅ Documents benefits clearly
 - ✅ Links to future work enabled
 
@@ -178,12 +144,6 @@ Even small PRs should have proper structure:
 
 - Fixed typo in error message: "converstion" → "conversation"
 - Updated help text for clarity
-
-## Test Plan
-
-- [ ] Verified error message displays correctly
-- [ ] All tests still pass
-- [ ] No functional changes
 
 ## Changes
 
@@ -202,7 +162,6 @@ N/A
 **Why this is good:**
 - ✅ Even small changes have context
 - ✅ Shows what changed and where
-- ✅ Confirms testing
 
 ---
 
@@ -215,13 +174,6 @@ N/A
 - Documented .drift.yaml schema for custom types
 - Included complete example configuration
 - Addressed common user questions from issues
-
-## Test Plan
-
-- [ ] Reviewed by 2 team members
-- [ ] All links work
-- [ ] Code examples are valid
-- [ ] Screenshots are clear
 
 ## Changes
 
@@ -253,28 +205,21 @@ Every PR answers:
 - **How:** How does it work?
 - **Impact:** What else might be affected?
 
-### 2. Testing is Thorough
-
-- Specific test files and scenarios listed
-- Coverage percentage stated
-- Manual testing documented
-- Edge cases covered
-
-### 3. Changes are Organized
+### 2. Changes are Organized
 
 - Grouped by Added/Modified/Removed
 - File paths with line numbers
 - Brief description of each change
 - No surprises for reviewer
 
-### 4. Trade-offs are Explained
+### 3. Trade-offs are Explained
 
 Good PRs explain decisions:
 - "Chose X over Y because Z"
 - "Trade-off: slightly more complexity for better testability"
 - "Alternative considered: A, but rejected because B"
 
-### 5. Size is Manageable
+### 4. Size is Manageable
 
 - Focused on one thing
 - Can be reviewed in reasonable time
@@ -289,9 +234,6 @@ A good PR is ready when:
 
 - [ ] Title follows format: `Issue #N: Description`
 - [ ] Summary explains what, why, and how
-- [ ] Test plan is specific and complete
-- [ ] All tests passing locally
-- [ ] All linters passing locally
 - [ ] Changes section shows what changed
 - [ ] Related issues linked
 - [ ] Branch is up to date with main
@@ -308,22 +250,17 @@ A good PR is ready when:
    - Help them understand quickly
    - Make review easy and fast
 
-2. **Show your work**
-   - Include test results
-   - Show coverage numbers
-   - List what you tested
-
-3. **Explain decisions**
+2. **Explain decisions**
    - Why this approach?
    - What else did you consider?
    - What are the trade-offs?
 
-4. **Keep it focused**
+3. **Keep it focused**
    - One feature/fix per PR
    - Separate refactoring from features
    - Split large changes if possible
 
-5. **Make it reviewable**
+4. **Make it reviewable**
    - Logical commits
    - Clear change descriptions
    - Easy to verify correctness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ drift --rules <names>    # Validate specific rules only
 drift draft --target-rule <rule_name>           # Generate prompt to stdout
 drift draft --target-rule <rule_name> --output prompt.md  # Save to file
 
+# Document: Generate documentation from rules
+drift document --rules <rule_name>              # Generate docs to stdout
+drift document --all --format html --output rules.html  # All rules in HTML
+
 # Optional: Conversation analysis
 drift                    # Analyze latest conversation (requires LLM)
 drift --days 7           # Analyze last 7 days

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -278,6 +278,40 @@ This workflow is especially useful when:
 - Scaffolding repetitive structures (skills, commands, agents)
 - Ensuring generated files meet all requirements from the start
 
+Generating Rule Documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``drift document`` to generate documentation from your rule definitions:
+
+.. code-block:: bash
+
+    # Document a single rule
+    drift document --rules skill_validation
+
+    # Document multiple rules
+    drift document --rules skill_validation,agent_validation --output docs.md
+
+    # Document all rules in HTML format
+    drift document --all --format html --output rules.html
+
+    # Use custom rules file
+    drift document --rules my_rule --rules-file custom_rules.yaml
+
+The generated documentation includes:
+
+- Rule description and context
+- Scope and metadata (severity, group name, supported clients)
+- Document bundle configuration
+- Validation phases with parameters
+- Draft instructions if defined
+
+This is useful for:
+
+- Creating reference documentation for your team
+- Sharing rule definitions across projects
+- Understanding complex validation logic
+- Onboarding new team members
+
 How Drift Works
 ---------------
 

--- a/src/drift/cli/commands/__init__.py
+++ b/src/drift/cli/commands/__init__.py
@@ -1,5 +1,5 @@
 """CLI commands for drift."""
 
-from drift.cli.commands import analyze, draft
+from drift.cli.commands import analyze, document, draft
 
-__all__ = ["analyze", "draft"]
+__all__ = ["analyze", "document", "draft"]

--- a/src/drift/cli/commands/document.py
+++ b/src/drift/cli/commands/document.py
@@ -1,0 +1,457 @@
+"""Document command for drift CLI.
+
+Generates documentation for Drift rules from their definitions in configuration files.
+Supports both .drift_rules.yaml and .claude/rules/ formats.
+"""
+
+import html
+import logging
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from drift.cli.logging_config import setup_logging
+from drift.config.loader import ConfigLoader
+from drift.config.models import DriftConfig, RuleDefinition
+
+logger = logging.getLogger(__name__)
+
+# ANSI color codes for terminal output
+RED = "\033[91m"
+YELLOW = "\033[93m"
+GREEN = "\033[92m"
+BLUE = "\033[94m"
+RESET = "\033[0m"
+
+
+def print_error(message: str) -> None:
+    """Print error message to stderr with red color.
+
+    -- message: Error message to print
+    """
+    print(f"{RED}{message}{RESET}", file=sys.stderr)
+
+
+def print_warning(message: str) -> None:
+    """Print warning message to stderr with yellow color.
+
+    -- message: Warning message to print
+    """
+    print(f"{YELLOW}{message}{RESET}", file=sys.stderr)
+
+
+def print_success(message: str) -> None:
+    """Print success message to stdout with green color.
+
+    -- message: Success message to print
+    """
+    print(f"{GREEN}{message}{RESET}")
+
+
+def format_rule_markdown(rule_name: str, rule_def: RuleDefinition, config: DriftConfig) -> str:
+    """Format a single rule definition as markdown documentation.
+
+    -- rule_name: Name of the rule
+    -- rule_def: Rule definition object
+    -- config: Full configuration object for context
+
+    Returns formatted markdown string.
+    """
+    lines = []
+
+    # Title
+    lines.append(f"# {rule_name}")
+    lines.append("")
+
+    # Description
+    lines.append("## Description")
+    lines.append("")
+    lines.append(rule_def.description)
+    lines.append("")
+
+    # Metadata
+    lines.append("## Metadata")
+    lines.append("")
+    lines.append(f"- **Scope**: {rule_def.scope}")
+    lines.append(f"- **Requires Project Context**: {rule_def.requires_project_context}")
+
+    # Severity
+    if rule_def.severity:
+        lines.append(f"- **Severity**: {rule_def.severity.value}")
+    else:
+        # Show default severity
+        default_severity = "warning" if rule_def.scope == "conversation_level" else "fail"
+        lines.append(f"- **Severity**: {default_severity} (default)")
+
+    # Group name
+    group_name = rule_def.group_name or config.default_group_name
+    lines.append(f"- **Group**: {group_name}")
+
+    # Supported clients
+    if rule_def.supported_clients:
+        lines.append(f"- **Supported Clients**: {', '.join(rule_def.supported_clients)}")
+    else:
+        lines.append("- **Supported Clients**: all")
+
+    lines.append("")
+
+    # Context
+    lines.append("## Context")
+    lines.append("")
+    lines.append(rule_def.context)
+    lines.append("")
+
+    # Document Bundle
+    if rule_def.document_bundle:
+        lines.append("## Document Bundle")
+        lines.append("")
+        lines.append(f"- **Bundle Type**: {rule_def.document_bundle.bundle_type}")
+        lines.append(f"- **Bundle Strategy**: {rule_def.document_bundle.bundle_strategy.value}")
+        lines.append("- **File Patterns**:")
+        for pattern in rule_def.document_bundle.file_patterns:
+            lines.append(f"  - `{pattern}`")
+        if rule_def.document_bundle.resource_patterns:
+            lines.append("- **Resource Patterns**:")
+            for pattern in rule_def.document_bundle.resource_patterns:
+                lines.append(f"  - `{pattern}`")
+        lines.append("")
+
+    # Validation Rules
+    if rule_def.validation_rules:
+        lines.append("## Validation Rules")
+        lines.append("")
+        for idx, val_rule in enumerate(rule_def.validation_rules.rules, start=1):
+            lines.append(f"### {idx}. {val_rule.rule_type}")
+            lines.append("")
+            lines.append(f"**Description**: {val_rule.description}")
+            lines.append("")
+            if val_rule.params:
+                lines.append("**Parameters**:")
+                for param_name, param_value in val_rule.params.items():
+                    lines.append(f"- `{param_name}`: {param_value}")
+                lines.append("")
+
+    # Phases
+    if rule_def.phases:
+        lines.append("## Phases")
+        lines.append("")
+        for idx, phase in enumerate(rule_def.phases, start=1):
+            lines.append(f"### {idx}. {phase.name}")
+            lines.append("")
+            lines.append(f"- **Type**: {phase.type}")
+            if phase.provider:
+                lines.append(f"- **Provider**: {phase.provider}")
+            if phase.model:
+                lines.append(f"- **Model**: {phase.model}")
+            if phase.prompt:
+                lines.append("")
+                lines.append("**Prompt**:")
+                lines.append("")
+                lines.append("```")
+                lines.append(phase.prompt.strip())
+                lines.append("```")
+            if phase.params:
+                lines.append("")
+                lines.append("**Parameters**:")
+                for param_name, param_value in phase.params.items():
+                    lines.append(f"- `{param_name}`: {param_value}")
+            if phase.available_resources:
+                lines.append("")
+                lines.append(f"**Available Resources**: {', '.join(phase.available_resources)}")
+            lines.append("")
+
+    # Draft Instructions
+    if rule_def.draft_instructions:
+        lines.append("## Draft Instructions")
+        lines.append("")
+        lines.append(rule_def.draft_instructions)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_rule_html(rule_name: str, rule_def: RuleDefinition, config: DriftConfig) -> str:
+    """Format a single rule definition as HTML documentation.
+
+    -- rule_name: Name of the rule
+    -- rule_def: Rule definition object
+    -- config: Full configuration object for context
+
+    Returns formatted HTML string.
+    """
+    lines = []
+
+    # Title
+    lines.append(f"<h1>{html.escape(rule_name)}</h1>")
+    lines.append("")
+
+    # Description
+    lines.append("<h2>Description</h2>")
+    lines.append(f"<p>{html.escape(rule_def.description)}</p>")
+    lines.append("")
+
+    # Metadata
+    lines.append("<h2>Metadata</h2>")
+    lines.append("<ul>")
+    lines.append(f"  <li><strong>Scope</strong>: {html.escape(rule_def.scope)}</li>")
+    lines.append(
+        f"  <li><strong>Requires Project Context</strong>: "
+        f"{html.escape(str(rule_def.requires_project_context))}</li>"
+    )
+
+    # Severity
+    if rule_def.severity:
+        severity_value = html.escape(rule_def.severity.value)
+        lines.append(f"  <li><strong>Severity</strong>: {severity_value}</li>")
+    else:
+        default_severity = "warning" if rule_def.scope == "conversation_level" else "fail"
+        severity_text = html.escape(default_severity)
+        lines.append(f"  <li><strong>Severity</strong>: {severity_text} (default)</li>")
+
+    # Group name
+    group_name = rule_def.group_name or config.default_group_name
+    lines.append(f"  <li><strong>Group</strong>: {html.escape(group_name)}</li>")
+
+    # Supported clients
+    if rule_def.supported_clients:
+        clients_str = ", ".join(rule_def.supported_clients)
+        lines.append(f"  <li><strong>Supported Clients</strong>: {html.escape(clients_str)}</li>")
+    else:
+        lines.append("  <li><strong>Supported Clients</strong>: all</li>")
+
+    lines.append("</ul>")
+    lines.append("")
+
+    # Context
+    lines.append("<h2>Context</h2>")
+    lines.append(f"<p>{html.escape(rule_def.context)}</p>")
+    lines.append("")
+
+    # Document Bundle
+    if rule_def.document_bundle:
+        lines.append("<h2>Document Bundle</h2>")
+        lines.append("<ul>")
+        lines.append(
+            f"  <li><strong>Bundle Type</strong>: "
+            f"{html.escape(rule_def.document_bundle.bundle_type)}</li>"
+        )
+        lines.append(
+            f"  <li><strong>Bundle Strategy</strong>: "
+            f"{html.escape(rule_def.document_bundle.bundle_strategy.value)}</li>"
+        )
+        lines.append("  <li><strong>File Patterns</strong>:")
+        lines.append("    <ul>")
+        for pattern in rule_def.document_bundle.file_patterns:
+            lines.append(f"      <li><code>{html.escape(pattern)}</code></li>")
+        lines.append("    </ul>")
+        lines.append("  </li>")
+        if rule_def.document_bundle.resource_patterns:
+            lines.append("  <li><strong>Resource Patterns</strong>:")
+            lines.append("    <ul>")
+            for pattern in rule_def.document_bundle.resource_patterns:
+                lines.append(f"      <li><code>{html.escape(pattern)}</code></li>")
+            lines.append("    </ul>")
+            lines.append("  </li>")
+        lines.append("</ul>")
+        lines.append("")
+
+    # Validation Rules
+    if rule_def.validation_rules:
+        lines.append("<h2>Validation Rules</h2>")
+        for idx, val_rule in enumerate(rule_def.validation_rules.rules, start=1):
+            rule_type_escaped = html.escape(val_rule.rule_type)
+            lines.append(f"<h3>{idx}. {rule_type_escaped}</h3>")
+            desc_escaped = html.escape(val_rule.description)
+            lines.append(f"<p><strong>Description</strong>: {desc_escaped}</p>")
+            if val_rule.params:
+                lines.append("<p><strong>Parameters</strong>:</p>")
+                lines.append("<ul>")
+                for param_name, param_value in val_rule.params.items():
+                    lines.append(
+                        f"  <li><code>{html.escape(param_name)}</code>: "
+                        f"{html.escape(str(param_value))}</li>"
+                    )
+                lines.append("</ul>")
+
+    # Phases
+    if rule_def.phases:
+        lines.append("<h2>Phases</h2>")
+        for idx, phase in enumerate(rule_def.phases, start=1):
+            lines.append(f"<h3>{idx}. {html.escape(phase.name)}</h3>")
+            lines.append("<ul>")
+            lines.append(f"  <li><strong>Type</strong>: {html.escape(phase.type)}</li>")
+            if phase.provider:
+                lines.append(f"  <li><strong>Provider</strong>: {html.escape(phase.provider)}</li>")
+            if phase.model:
+                lines.append(f"  <li><strong>Model</strong>: {html.escape(phase.model)}</li>")
+            if phase.prompt:
+                lines.append("</ul>")
+                lines.append("<p><strong>Prompt</strong>:</p>")
+                lines.append(f"<pre><code>{html.escape(phase.prompt.strip())}</code></pre>")
+                lines.append("<ul>")
+            if phase.params:
+                lines.append("  <li><strong>Parameters</strong>:")
+                lines.append("    <ul>")
+                for param_name, param_value in phase.params.items():
+                    lines.append(
+                        f"      <li><code>{html.escape(param_name)}</code>: "
+                        f"{html.escape(str(param_value))}</li>"
+                    )
+                lines.append("    </ul>")
+                lines.append("  </li>")
+            if phase.available_resources:
+                resources_str = ", ".join(phase.available_resources)
+                lines.append(
+                    f"  <li><strong>Available Resources</strong>: "
+                    f"{html.escape(resources_str)}</li>"
+                )
+            lines.append("</ul>")
+
+    # Draft Instructions
+    if rule_def.draft_instructions:
+        lines.append("<h2>Draft Instructions</h2>")
+        lines.append(f"<p>{html.escape(rule_def.draft_instructions)}</p>")
+
+    return "\n".join(lines)
+
+
+def document_command(
+    rules: Optional[str] = None,
+    all_rules: bool = False,
+    output: Optional[str] = None,
+    format_type: str = "markdown",
+    project: Optional[str] = None,
+    rules_file: Optional[List[str]] = None,
+    verbose: int = 0,
+) -> None:
+    """Generate documentation for Drift rules.
+
+    This command reads rule definitions from configuration and generates
+    documentation in markdown or HTML format. The output is either printed
+    to stdout or saved to a file.
+
+    -- rules: Comma-separated list of rule names to document
+    -- all_rules: If True, document all loaded rules
+    -- output: Output file path (if None, prints to stdout)
+    -- format_type: Output format ('markdown' or 'html')
+    -- project: Project path (if None, uses current directory)
+    -- rules_file: List of custom rules files to load
+    -- verbose: Verbosity level (0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG)
+    """
+    setup_logging(verbose)
+
+    try:
+        # Ensure global config exists on first run
+        ConfigLoader.ensure_global_config_exists()
+
+        # Determine project path
+        project_path = Path(project) if project else Path.cwd()
+        if not project_path.exists():
+            print_error(f"Error: Project path does not exist: {project_path}")
+            sys.exit(1)
+
+        # Load configuration
+        try:
+            config = ConfigLoader.load_config(project_path, rules_files=rules_file)
+        except ValueError as e:
+            print_error(f"Configuration error: {e}")
+            sys.exit(1)
+
+        # Determine which rules to document
+        if all_rules:
+            rule_names = list(config.rule_definitions.keys())
+        elif rules:
+            rule_names = [r.strip() for r in rules.split(",")]
+        else:
+            print_error("Error: Must specify either --rules or --all")
+            print_error("Usage:")
+            print_error("  drift document --rules skill_validation,agent_validation")
+            print_error("  drift document --all")
+            sys.exit(1)
+
+        # Validate all rule names exist
+        missing_rules = [r for r in rule_names if r not in config.rule_definitions]
+        if missing_rules:
+            print_error(f"Error: Rules not found: {', '.join(missing_rules)}")
+            available_rules = ", ".join(config.rule_definitions.keys())
+            print_error(f"Available rules: {available_rules}")
+            sys.exit(1)
+
+        # Generate documentation
+        output_lines = []
+
+        # Add header for multi-rule documentation
+        if len(rule_names) > 1:
+            if format_type == "markdown":
+                output_lines.append("# Drift Rules Documentation")
+                output_lines.append("")
+                output_lines.append(f"Documentation for {len(rule_names)} rules.")
+                output_lines.append("")
+                output_lines.append("---")
+                output_lines.append("")
+            elif format_type == "html":
+                output_lines.append("<!DOCTYPE html>")
+                output_lines.append("<html>")
+                output_lines.append("<head>")
+                output_lines.append('  <meta charset="UTF-8">')
+                output_lines.append("  <title>Drift Rules Documentation</title>")
+                output_lines.append("</head>")
+                output_lines.append("<body>")
+                output_lines.append("  <h1>Drift Rules Documentation</h1>")
+                output_lines.append(f"  <p>Documentation for {len(rule_names)} rules.</p>")
+                output_lines.append("  <hr>")
+                output_lines.append("")
+
+        # Generate documentation for each rule
+        for idx, rule_name in enumerate(rule_names):
+            rule_def = config.rule_definitions[rule_name]
+
+            if format_type == "markdown":
+                doc = format_rule_markdown(rule_name, rule_def, config)
+            elif format_type == "html":
+                doc = format_rule_html(rule_name, rule_def, config)
+            else:
+                print_error(f"Error: Unsupported format '{format_type}'. Use 'markdown' or 'html'.")
+                sys.exit(1)
+
+            output_lines.append(doc)
+
+            # Add separator between rules (except after last rule)
+            if idx < len(rule_names) - 1:
+                if format_type == "markdown":
+                    output_lines.append("---")
+                    output_lines.append("")
+                elif format_type == "html":
+                    output_lines.append("<hr>")
+                    output_lines.append("")
+
+        # Add footer for HTML
+        if len(rule_names) > 1 and format_type == "html":
+            output_lines.append("</body>")
+            output_lines.append("</html>")
+
+        documentation = "\n".join(output_lines)
+
+        # Output documentation
+        if output:
+            output_path = Path(output)
+            try:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(documentation, encoding="utf-8")
+                print_success(f"Documentation written to: {output_path}")
+            except Exception as e:
+                print_error(f"Error writing to file: {e}")
+                sys.exit(1)
+        else:
+            # Print to stdout
+            print(documentation)
+
+        sys.exit(0)
+
+    except KeyboardInterrupt:
+        print_error("\nDocument interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        logger.exception("Unexpected error during document")
+        print_error(f"Unexpected error: {e}")
+        sys.exit(1)

--- a/src/drift/cli/main.py
+++ b/src/drift/cli/main.py
@@ -3,7 +3,7 @@
 import argparse
 from importlib.metadata import version
 
-from drift.cli.commands import analyze, draft
+from drift.cli.commands import analyze, document, draft
 
 __version__ = version("ai-drift")
 
@@ -51,6 +51,11 @@ Examples:
   drift draft --target-rule skill_validation
   drift draft --target-rule skill_validation --output prompt.md
   drift draft --target-rule skill_validation --target-file .claude/skills/testing/SKILL.md
+
+  # Document command - generate rule documentation
+  drift document --rules skill_validation
+  drift document --rules skill_validation,agent_validation --output docs.md
+  drift document --all --format html --output rules.html
         """,
     )
 
@@ -93,6 +98,59 @@ Examples:
         help="Project path (defaults to current directory)",
     )
     draft_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="count",
+        default=0,
+        help="Increase verbosity (-v for INFO, -vv for DEBUG)",
+    )
+
+    # Document subcommand
+    document_parser = subparsers.add_parser(
+        "document",
+        help="Generate documentation for Drift rules",
+        description="Generate documentation from rule definitions",
+    )
+    document_parser.add_argument(
+        "--rules",
+        "-r",
+        default=None,
+        help="Comma-separated list of rule names to document",
+    )
+    document_parser.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_rules",
+        help="Document all loaded rules",
+    )
+    document_parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    document_parser.add_argument(
+        "--format",
+        "-f",
+        default="markdown",
+        choices=["markdown", "html"],
+        help="Output format (default: markdown)",
+    )
+    document_parser.add_argument(
+        "--project",
+        "-p",
+        default=None,
+        help="Project path (defaults to current directory)",
+    )
+    document_parser.add_argument(
+        "--rules-file",
+        action="append",
+        default=None,
+        help=(
+            "Path to rules file (local file or HTTP(S) URL). " "Can be specified multiple times."
+        ),
+    )
+    document_parser.add_argument(
         "--verbose",
         "-v",
         action="count",
@@ -234,6 +292,17 @@ def main() -> None:
             output=args.output,
             force=args.force,
             project=args.project,
+            verbose=args.verbose,
+        )
+    elif args.command == "document":
+        # Call document command
+        document.document_command(
+            rules=args.rules,
+            all_rules=args.all_rules,
+            output=args.output,
+            format_type=args.format,
+            project=args.project,
+            rules_file=args.rules_file,
             verbose=args.verbose,
         )
     else:

--- a/tests/unit/test_document_command.py
+++ b/tests/unit/test_document_command.py
@@ -1,0 +1,1045 @@
+"""Unit tests for document command."""
+
+from unittest.mock import patch
+
+import pytest
+
+from drift.cli.commands.document import (
+    document_command,
+    format_rule_html,
+    format_rule_markdown,
+    print_error,
+    print_success,
+    print_warning,
+)
+from drift.config.models import (
+    BundleStrategy,
+    DocumentBundleConfig,
+    DriftConfig,
+    ModelConfig,
+    PhaseDefinition,
+    ProviderConfig,
+    ProviderType,
+    RuleDefinition,
+    SeverityLevel,
+    ValidationRule,
+    ValidationRulesConfig,
+)
+
+
+class TestDocumentCommand:
+    """Tests for document_command function."""
+
+    @pytest.fixture
+    def sample_rule(self):
+        """Create a sample rule for testing."""
+        return RuleDefinition(
+            description="Test skill validation",
+            scope="project_level",
+            context="Skills need documentation",
+            requires_project_context=True,
+            severity=SeverityLevel.FAIL,
+            group_name="Testing",
+            supported_clients=["claude-code"],
+            document_bundle=DocumentBundleConfig(
+                bundle_type="skill",
+                file_patterns=[".claude/skills/*/SKILL.md"],
+                bundle_strategy=BundleStrategy.INDIVIDUAL,
+            ),
+            phases=[
+                PhaseDefinition(
+                    name="check_file",
+                    type="core:file_exists",
+                    params={"file_path": "SKILL.md"},
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def sample_config(self, sample_rule):
+        """Create a sample config with rule."""
+        return DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            default_group_name="General",
+            rule_definitions={"skill_validation": sample_rule},
+        )
+
+    def test_document_no_rules_or_all_flag(self, temp_dir, sample_config):
+        """Test error when neither --rules nor --all is specified."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    project=str(temp_dir),
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 1
+
+    def test_document_rule_not_found(self, temp_dir, sample_config):
+        """Test error when specified rule doesn't exist."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="nonexistent_rule",
+                    project=str(temp_dir),
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 1
+
+    def test_document_single_rule_markdown_stdout(self, temp_dir, sample_config, capsys):
+        """Test documenting single rule to stdout in markdown format."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    format_type="markdown",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            assert "# skill_validation" in captured.out
+            assert "Test skill validation" in captured.out
+            assert "## Description" in captured.out
+            assert "## Metadata" in captured.out
+            assert "## Context" in captured.out
+            assert "## Document Bundle" in captured.out
+            assert "## Phases" in captured.out
+
+    def test_document_single_rule_html_stdout(self, temp_dir, sample_config, capsys):
+        """Test documenting single rule to stdout in HTML format."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    format_type="html",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            assert "<h1>skill_validation</h1>" in captured.out
+            assert "<h2>Description</h2>" in captured.out
+            assert "<h2>Metadata</h2>" in captured.out
+            assert "Test skill validation" in captured.out
+
+    def test_document_multiple_rules_markdown(self, temp_dir, capsys):
+        """Test documenting multiple rules to stdout in markdown format."""
+        rule1 = RuleDefinition(
+            description="First rule",
+            scope="project_level",
+            context="Context 1",
+            requires_project_context=True,
+        )
+        rule2 = RuleDefinition(
+            description="Second rule",
+            scope="project_level",
+            context="Context 2",
+            requires_project_context=False,
+        )
+
+        config = DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            rule_definitions={
+                "rule1": rule1,
+                "rule2": rule2,
+            },
+        )
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="rule1,rule2",
+                    project=str(temp_dir),
+                    format_type="markdown",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            assert "# Drift Rules Documentation" in captured.out
+            assert "Documentation for 2 rules" in captured.out
+            assert "# rule1" in captured.out
+            assert "# rule2" in captured.out
+            assert "First rule" in captured.out
+            assert "Second rule" in captured.out
+            assert "---" in captured.out
+
+    def test_document_all_rules_markdown(self, temp_dir, sample_config, capsys):
+        """Test documenting all rules with --all flag."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    all_rules=True,
+                    project=str(temp_dir),
+                    format_type="markdown",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            assert "# skill_validation" in captured.out
+            assert "Test skill validation" in captured.out
+
+    def test_document_write_to_file(self, temp_dir, sample_config):
+        """Test documenting rule to output file."""
+        output_file = temp_dir / "documentation.md"
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    output=str(output_file),
+                    format_type="markdown",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+        # Check file was created
+        assert output_file.exists()
+        content = output_file.read_text()
+        assert "# skill_validation" in content
+        assert "Test skill validation" in content
+
+    def test_document_write_to_file_creates_directories(self, temp_dir, sample_config):
+        """Test that document creates parent directories for output file."""
+        output_file = temp_dir / "nested" / "dir" / "documentation.md"
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    output=str(output_file),
+                    format_type="markdown",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+        # Check file and directories were created
+        assert output_file.exists()
+        assert output_file.parent.exists()
+
+    def test_document_output_file_write_error(self, temp_dir, sample_config):
+        """Test error handling when output file can't be written."""
+        # Use invalid path for output
+        output_file = "/invalid/path/to/file.md"
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    output=output_file,
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 1
+
+    def test_document_invalid_format(self, temp_dir, sample_config):
+        """Test error when invalid format is specified."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    format_type="invalid_format",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 1
+
+    def test_document_config_load_error(self, temp_dir):
+        """Test error handling when config loading fails."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.side_effect = ValueError("Invalid config")
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 1
+
+    def test_document_project_path_not_exists(self):
+        """Test error when project path doesn't exist."""
+        with pytest.raises(SystemExit) as exc_info:
+            document_command(
+                rules="skill_validation",
+                project="/nonexistent/path",
+                verbose=0,
+            )
+
+        assert exc_info.value.code == 1
+
+    def test_document_uses_current_dir_when_no_project(self, temp_dir, sample_config):
+        """Test that document uses current directory when project not specified."""
+        import os
+
+        # Change to temp_dir so Path.cwd() returns a valid path
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(temp_dir)
+
+            with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+                mock_load.return_value = sample_config
+
+                with pytest.raises(SystemExit) as exc_info:
+                    document_command(
+                        rules="skill_validation",
+                        verbose=0,
+                    )
+
+                assert exc_info.value.code == 0
+
+                # Check that load_config was called with current directory (temp_dir)
+                mock_load.assert_called_once()
+                # Resolve both paths to handle macOS /var -> /private/var symlink
+                assert mock_load.call_args[0][0].resolve() == temp_dir.resolve()
+        finally:
+            os.chdir(original_cwd)
+
+    def test_document_with_custom_rules_file(self, temp_dir, sample_config):
+        """Test documenting with custom rules file."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    rules_file=["custom_rules.yaml"],
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            # Verify rules_file was passed to config loader
+            mock_load.assert_called_once()
+            assert mock_load.call_args[1]["rules_files"] == ["custom_rules.yaml"]
+
+    def test_document_keyboard_interrupt(self, temp_dir, sample_config):
+        """Test handling of keyboard interrupt."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.side_effect = KeyboardInterrupt()
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 1
+
+    def test_document_unexpected_error(self, temp_dir, sample_config):
+        """Test handling of unexpected errors."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.side_effect = RuntimeError("Unexpected error")
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="skill_validation",
+                    project=str(temp_dir),
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 1
+
+    def test_document_verbosity_levels(self, temp_dir, sample_config):
+        """Test that different verbosity levels work."""
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = sample_config
+
+            # Test various verbosity levels
+            for verbose_level in [0, 1, 2, 3]:
+                with pytest.raises(SystemExit) as exc_info:
+                    document_command(
+                        rules="skill_validation",
+                        project=str(temp_dir),
+                        verbose=verbose_level,
+                    )
+
+                assert exc_info.value.code == 0
+
+    def test_document_rule_with_all_fields(self, temp_dir, capsys):
+        """Test documenting a rule with all possible fields populated."""
+        rule = RuleDefinition(
+            description="Comprehensive test rule",
+            scope="conversation_level",
+            context="Full context example",
+            requires_project_context=False,
+            severity=SeverityLevel.WARNING,
+            group_name="TestGroup",
+            supported_clients=["claude-code", "other-client"],
+            document_bundle=DocumentBundleConfig(
+                bundle_type="test",
+                file_patterns=["test/*.md"],
+                bundle_strategy=BundleStrategy.COLLECTION,
+                resource_patterns=["**/*.py"],
+            ),
+            phases=[
+                PhaseDefinition(
+                    name="phase1",
+                    type="prompt",
+                    model="sonnet",
+                    prompt="Test prompt content",
+                    available_resources=["skill", "command"],
+                ),
+                PhaseDefinition(
+                    name="phase2",
+                    type="core:file_exists",
+                    params={"file_path": "test.md"},
+                ),
+            ],
+            draft_instructions="Custom draft instructions for {file_path}",
+        )
+
+        config = DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            default_group_name="General",
+            rule_definitions={"full_rule": rule},
+        )
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="full_rule",
+                    project=str(temp_dir),
+                    format_type="markdown",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            # Check all sections are present
+            assert "# full_rule" in captured.out
+            assert "Comprehensive test rule" in captured.out
+            assert "conversation_level" in captured.out
+            assert "warning" in captured.out
+            assert "TestGroup" in captured.out
+            assert "claude-code, other-client" in captured.out
+            assert "## Document Bundle" in captured.out
+            assert "## Phases" in captured.out
+            assert "Test prompt content" in captured.out
+            assert "## Draft Instructions" in captured.out
+            assert "Custom draft instructions" in captured.out
+
+    def test_document_rule_with_minimal_fields(self, temp_dir, capsys):
+        """Test documenting a rule with only required fields."""
+        rule = RuleDefinition(
+            description="Minimal test rule",
+            scope="project_level",
+            context="Minimal context",
+            requires_project_context=True,
+        )
+
+        config = DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            default_group_name="General",
+            rule_definitions={"minimal_rule": rule},
+        )
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="minimal_rule",
+                    project=str(temp_dir),
+                    format_type="markdown",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            assert "# minimal_rule" in captured.out
+            assert "Minimal test rule" in captured.out
+            # Check default severity is shown
+            assert "fail (default)" in captured.out
+            # Check default group is shown
+            assert "General" in captured.out
+
+    def test_document_html_escaping(self, temp_dir, capsys):
+        """Test that HTML format properly escapes special characters."""
+        rule = RuleDefinition(
+            description='Rule with <special> & "characters"',
+            scope="project_level",
+            context="Context with <html> & 'quotes'",
+            requires_project_context=True,
+        )
+
+        config = DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            rule_definitions={"escape_test": rule},
+        )
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="escape_test",
+                    project=str(temp_dir),
+                    format_type="html",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            # Special characters should be escaped
+            assert "&lt;special&gt;" in captured.out
+            assert "&amp;" in captured.out
+            assert "&lt;html&gt;" in captured.out
+
+    def test_document_multiple_rules_html_format(self, temp_dir, capsys):
+        """Test documenting multiple rules in HTML format includes proper wrapper."""
+        rule1 = RuleDefinition(
+            description="First rule",
+            scope="project_level",
+            context="Context 1",
+            requires_project_context=True,
+        )
+        rule2 = RuleDefinition(
+            description="Second rule",
+            scope="project_level",
+            context="Context 2",
+            requires_project_context=False,
+        )
+
+        config = DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            rule_definitions={
+                "rule1": rule1,
+                "rule2": rule2,
+            },
+        )
+
+        with patch("drift.cli.commands.document.ConfigLoader.load_config") as mock_load:
+            mock_load.return_value = config
+
+            with pytest.raises(SystemExit) as exc_info:
+                document_command(
+                    rules="rule1,rule2",
+                    project=str(temp_dir),
+                    format_type="html",
+                    verbose=0,
+                )
+
+            assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            # Check HTML document structure
+            assert "<!DOCTYPE html>" in captured.out
+            assert "<html>" in captured.out
+            assert "<head>" in captured.out
+            assert "<title>Drift Rules Documentation</title>" in captured.out
+            assert "</head>" in captured.out
+            assert "<body>" in captured.out
+            assert "</body>" in captured.out
+            assert "</html>" in captured.out
+            assert "Documentation for 2 rules" in captured.out
+
+
+class TestPrintFunctions:
+    """Tests for print_error, print_warning, and print_success functions."""
+
+    def test_print_error_message_to_stderr(self, capsys):
+        """Test that print_error outputs to stderr with color."""
+        print_error("Test error message")
+
+        captured = capsys.readouterr()
+        assert "Test error message" in captured.err
+        assert captured.out == ""
+
+    def test_print_warning_message_to_stderr(self, capsys):
+        """Test that print_warning outputs to stderr with color."""
+        print_warning("Test warning message")
+
+        captured = capsys.readouterr()
+        assert "Test warning message" in captured.err
+        assert captured.out == ""
+
+    def test_print_success_message_to_stdout(self, capsys):
+        """Test that print_success outputs to stdout with color."""
+        print_success("Test success message")
+
+        captured = capsys.readouterr()
+        assert "Test success message" in captured.out
+        assert captured.err == ""
+
+
+class TestFormatRuleMarkdown:
+    """Tests for format_rule_markdown function."""
+
+    @pytest.fixture
+    def minimal_config(self):
+        """Create minimal config for testing."""
+        return DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            default_group_name="DefaultGroup",
+            rule_definitions={},
+        )
+
+    def test_format_rule_markdown_minimal_rule(self, minimal_config):
+        """Test formatting minimal rule to markdown."""
+        rule = RuleDefinition(
+            description="Simple test",
+            scope="project_level",
+            context="Test context",
+            requires_project_context=True,
+        )
+
+        output = format_rule_markdown("test_rule", rule, minimal_config)
+
+        assert "# test_rule" in output
+        assert "## Description" in output
+        assert "Simple test" in output
+        assert "## Metadata" in output
+        assert "project_level" in output
+        assert "True" in output
+        assert "## Context" in output
+        assert "Test context" in output
+        assert "DefaultGroup" in output
+
+    def test_format_rule_markdown_with_validation_rules(self, minimal_config):
+        """Test formatting rule with validation rules."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            validation_rules=ValidationRulesConfig(
+                rules=[
+                    ValidationRule(
+                        rule_type="core:file_exists",
+                        description="Check file exists",
+                        params={"file_path": "test.md", "other_param": 123},
+                    ),
+                    ValidationRule(
+                        rule_type="core:regex_match",
+                        description="Check pattern",
+                        params={"pattern": "test.*"},
+                    ),
+                ],
+                document_bundle=DocumentBundleConfig(
+                    bundle_type="test",
+                    file_patterns=["*.md"],
+                    bundle_strategy=BundleStrategy.INDIVIDUAL,
+                ),
+            ),
+        )
+
+        output = format_rule_markdown("validation_test", rule, minimal_config)
+
+        assert "## Validation Rules" in output
+        assert "### 1. core:file_exists" in output
+        assert "Check file exists" in output
+        assert "`file_path`: test.md" in output
+        assert "`other_param`: 123" in output
+        assert "### 2. core:regex_match" in output
+        assert "Check pattern" in output
+
+    def test_format_rule_markdown_with_phases_all_fields(self, minimal_config):
+        """Test formatting rule with phases containing all fields."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            phases=[
+                PhaseDefinition(
+                    name="test_phase",
+                    type="prompt",
+                    provider="bedrock",
+                    model="claude-v2",
+                    prompt="This is a test prompt\nwith multiple lines",
+                    params={"temperature": 0.7, "max_tokens": 1000},
+                    available_resources=["skill", "agent", "command"],
+                ),
+            ],
+        )
+
+        output = format_rule_markdown("phase_test", rule, minimal_config)
+
+        assert "## Phases" in output
+        assert "### 1. test_phase" in output
+        assert "- **Type**: prompt" in output
+        assert "- **Provider**: bedrock" in output
+        assert "- **Model**: claude-v2" in output
+        assert "**Prompt**:" in output
+        assert "This is a test prompt" in output
+        assert "with multiple lines" in output
+        assert "**Parameters**:" in output
+        assert "`temperature`: 0.7" in output
+        assert "`max_tokens`: 1000" in output
+        assert "**Available Resources**: skill, agent, command" in output
+
+    def test_format_rule_markdown_with_draft_instructions(self, minimal_config):
+        """Test formatting rule with draft instructions."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            draft_instructions="Custom instructions for {file_path}\nwith placeholders",
+        )
+
+        output = format_rule_markdown("draft_test", rule, minimal_config)
+
+        assert "## Draft Instructions" in output
+        assert "Custom instructions for {file_path}" in output
+        assert "with placeholders" in output
+
+    def test_format_rule_markdown_severity_explicit(self, minimal_config):
+        """Test formatting rule with explicit severity."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            severity=SeverityLevel.WARNING,
+        )
+
+        output = format_rule_markdown("severity_test", rule, minimal_config)
+
+        assert "**Severity**: warning" in output
+        assert "(default)" not in output
+
+    def test_format_rule_markdown_severity_default_conversation(self, minimal_config):
+        """Test formatting conversation-level rule uses default severity warning."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="conversation_level",
+            context="Context",
+            requires_project_context=False,
+        )
+
+        output = format_rule_markdown("conv_test", rule, minimal_config)
+
+        assert "**Severity**: warning (default)" in output
+
+    def test_format_rule_markdown_severity_default_project(self, minimal_config):
+        """Test formatting project-level rule uses default severity fail."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+        )
+
+        output = format_rule_markdown("proj_test", rule, minimal_config)
+
+        assert "**Severity**: fail (default)" in output
+
+    def test_format_rule_markdown_explicit_group_name(self, minimal_config):
+        """Test formatting rule with explicit group name."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            group_name="CustomGroup",
+        )
+
+        output = format_rule_markdown("group_test", rule, minimal_config)
+
+        assert "**Group**: CustomGroup" in output
+
+    def test_format_rule_markdown_supported_clients_explicit(self, minimal_config):
+        """Test formatting rule with explicit supported clients."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            supported_clients=["claude-code", "other-client"],
+        )
+
+        output = format_rule_markdown("clients_test", rule, minimal_config)
+
+        assert "**Supported Clients**: claude-code, other-client" in output
+
+    def test_format_rule_markdown_supported_clients_default(self, minimal_config):
+        """Test formatting rule without supported clients shows all."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+        )
+
+        output = format_rule_markdown("default_clients", rule, minimal_config)
+
+        assert "**Supported Clients**: all" in output
+
+    def test_format_rule_markdown_document_bundle_with_resources(self, minimal_config):
+        """Test formatting rule with document bundle including resources."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            document_bundle=DocumentBundleConfig(
+                bundle_type="test",
+                file_patterns=["*.md", "**/*.txt"],
+                bundle_strategy=BundleStrategy.INDIVIDUAL,
+                resource_patterns=["**/*.py", "src/**/*.rs"],
+            ),
+        )
+
+        output = format_rule_markdown("bundle_test", rule, minimal_config)
+
+        assert "## Document Bundle" in output
+        assert "- **Bundle Type**: test" in output
+        assert "- **Bundle Strategy**: individual" in output
+        assert "- **File Patterns**:" in output
+        assert "  - `*.md`" in output
+        assert "  - `**/*.txt`" in output
+        assert "- **Resource Patterns**:" in output
+        assert "  - `**/*.py`" in output
+        assert "  - `src/**/*.rs`" in output
+
+
+class TestFormatRuleHTML:
+    """Tests for format_rule_html function."""
+
+    @pytest.fixture
+    def minimal_config(self):
+        """Create minimal config for testing."""
+        return DriftConfig(
+            providers={"bedrock": ProviderConfig(provider=ProviderType.BEDROCK, params={})},
+            models={"haiku": ModelConfig(provider="bedrock", model_id="test-model", params={})},
+            default_model="haiku",
+            default_group_name="DefaultGroup",
+            rule_definitions={},
+        )
+
+    def test_format_rule_html_minimal_rule(self, minimal_config):
+        """Test formatting minimal rule to HTML."""
+        rule = RuleDefinition(
+            description="Simple test",
+            scope="project_level",
+            context="Test context",
+            requires_project_context=True,
+        )
+
+        output = format_rule_html("test_rule", rule, minimal_config)
+
+        assert "<h1>test_rule</h1>" in output
+        assert "<h2>Description</h2>" in output
+        assert "<p>Simple test</p>" in output
+        assert "<h2>Metadata</h2>" in output
+        assert "<ul>" in output
+        assert "project_level" in output
+        assert "True" in output
+        assert "<h2>Context</h2>" in output
+        assert "Test context" in output
+
+    def test_format_rule_html_escapes_special_characters(self, minimal_config):
+        """Test that HTML format escapes special characters."""
+        rule = RuleDefinition(
+            description='Rule with <tags> & "quotes"',
+            scope="project_level",
+            context='Context with <script> & "data"',
+            requires_project_context=True,
+        )
+
+        output = format_rule_html("escape_test", rule, minimal_config)
+
+        # Check that special characters are escaped
+        assert "&lt;tags&gt;" in output
+        assert "&amp;" in output
+        assert "&quot;" in output
+        assert "&lt;script&gt;" in output
+        # Should not contain raw special characters
+        assert "<tags>" not in output
+        assert "<script>" not in output
+
+    def test_format_rule_html_with_validation_rules(self, minimal_config):
+        """Test formatting rule with validation rules in HTML."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            validation_rules=ValidationRulesConfig(
+                rules=[
+                    ValidationRule(
+                        rule_type="core:file_exists",
+                        description="Check file exists",
+                        params={"file_path": "test.md", "count": 5},
+                    ),
+                ],
+                document_bundle=DocumentBundleConfig(
+                    bundle_type="test",
+                    file_patterns=["*.md"],
+                    bundle_strategy=BundleStrategy.INDIVIDUAL,
+                ),
+            ),
+        )
+
+        output = format_rule_html("validation_test", rule, minimal_config)
+
+        assert "<h2>Validation Rules</h2>" in output
+        assert "<h3>1. core:file_exists</h3>" in output
+        assert "Check file exists" in output
+        assert "<code>file_path</code>" in output
+        assert "test.md" in output
+        assert "<code>count</code>" in output
+        assert "5" in output
+
+    def test_format_rule_html_with_phases_all_fields(self, minimal_config):
+        """Test formatting rule with phases containing all fields in HTML."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            phases=[
+                PhaseDefinition(
+                    name="test_phase",
+                    type="prompt",
+                    provider="bedrock",
+                    model="claude-v2",
+                    prompt="Test prompt with <tags>",
+                    params={"temperature": 0.7},
+                    available_resources=["skill", "agent"],
+                ),
+            ],
+        )
+
+        output = format_rule_html("phase_test", rule, minimal_config)
+
+        assert "<h2>Phases</h2>" in output
+        assert "<h3>1. test_phase</h3>" in output
+        assert "<strong>Type</strong>: prompt" in output
+        assert "<strong>Provider</strong>: bedrock" in output
+        assert "<strong>Model</strong>: claude-v2" in output
+        assert "<p><strong>Prompt</strong>:</p>" in output
+        assert "<pre><code>" in output
+        assert "&lt;tags&gt;" in output  # Should be escaped
+        assert "<strong>Parameters</strong>:" in output
+        assert "<code>temperature</code>" in output
+        assert "0.7" in output
+        assert "<strong>Available Resources</strong>: skill, agent" in output
+
+    def test_format_rule_html_with_draft_instructions(self, minimal_config):
+        """Test formatting rule with draft instructions in HTML."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            draft_instructions="Custom <instructions> & {placeholders}",
+        )
+
+        output = format_rule_html("draft_test", rule, minimal_config)
+
+        assert "<h2>Draft Instructions</h2>" in output
+        assert "&lt;instructions&gt;" in output
+        assert "{placeholders}" in output
+
+    def test_format_rule_html_severity_explicit(self, minimal_config):
+        """Test formatting rule with explicit severity in HTML."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            severity=SeverityLevel.FAIL,
+        )
+
+        output = format_rule_html("severity_test", rule, minimal_config)
+
+        assert "<strong>Severity</strong>: fail" in output
+        assert "(default)" not in output
+
+    def test_format_rule_html_severity_default_conversation(self, minimal_config):
+        """Test formatting conversation-level rule severity in HTML."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="conversation_level",
+            context="Context",
+            requires_project_context=False,
+        )
+
+        output = format_rule_html("conv_test", rule, minimal_config)
+
+        assert "<strong>Severity</strong>: warning (default)" in output
+
+    def test_format_rule_html_document_bundle_with_resources(self, minimal_config):
+        """Test formatting rule with document bundle including resources in HTML."""
+        rule = RuleDefinition(
+            description="Test",
+            scope="project_level",
+            context="Context",
+            requires_project_context=True,
+            document_bundle=DocumentBundleConfig(
+                bundle_type="test",
+                file_patterns=["*.md"],
+                bundle_strategy=BundleStrategy.COLLECTION,
+                resource_patterns=["**/*.py"],
+            ),
+        )
+
+        output = format_rule_html("bundle_test", rule, minimal_config)
+
+        assert "<h2>Document Bundle</h2>" in output
+        assert "<strong>Bundle Type</strong>: test" in output
+        assert "<strong>Bundle Strategy</strong>: collection" in output
+        assert "<strong>File Patterns</strong>:" in output
+        assert "<code>*.md</code>" in output
+        assert "<strong>Resource Patterns</strong>:" in output
+        assert "<code>**/*.py</code>" in output


### PR DESCRIPTION
## Summary

- Added `drift document` subcommand for generating documentation from drift rules
- Supports markdown and HTML output formats with proper escaping
- Enables single rule, multiple rules (comma-separated), or all rules documentation
- Outputs to stdout or file with configurable formatting
- Respects base `--rules-file` flag for custom rule loading

## Changes

### Added
- `src/drift/cli/commands/document.py` - Document command implementation (457 lines)
- `tests/unit/test_document_command.py` - Comprehensive test suite (1,045 lines, 43 tests)

### Modified
- `src/drift/cli/commands/__init__.py` - Added document command import
- `src/drift/cli/main.py` - Added document subcommand parser and handler
- `CLAUDE.md` - Added document command examples to Key Commands
- `docs/quickstart.rst` - Added "Generating Rule Documentation" section

## Related Issues

Closes #56